### PR TITLE
[Feature] - customize proposal form

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
-//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,4 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require_tree .
 //= require decidim

--- a/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
+++ b/app/assets/javascripts/decidim/proposals/add_proposal.js.es6
@@ -1,0 +1,17 @@
+$(() => {
+    const { attachGeocoding } = window.Decidim;
+
+    window.DecidimProposals = window.DecidimProposals || {};
+
+    window.DecidimProposals.bindProposalAddress = () => {
+        const $checkbox = $("input:checkbox[name$='[has_address]']");
+        const $addressInput = $("#address_input");
+        const $addressInputField = $("input", $addressInput);
+
+        if ($addressInput.length > 0) {
+            attachGeocoding($addressInputField);
+        }
+    };
+
+    window.DecidimProposals.bindProposalAddress();
+});

--- a/app/forms/decidim/proposals/proposal_form.rb
+++ b/app/forms/decidim/proposals/proposal_form.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A form object to be used when public users want to create a proposal.
+    class ProposalForm < Decidim::Proposals::ProposalWizardCreateStepForm
+      include Decidim::TranslatableAttributes
+      include Decidim::AttachmentAttributes
+
+      mimic :proposal
+
+      attribute :address, String
+      attribute :latitude, Float
+      attribute :longitude, Float
+      attribute :category_id, Integer
+      attribute :scope_id, Integer
+      attribute :attachment, AttachmentForm
+      attribute :suggested_hashtags, Array[String]
+
+      attachments_attribute :photos
+      attachments_attribute :documents
+
+      validates :address, geocoding: true, if: ->(form) { has_address? && !form.geocoded? }
+      validates :category, presence: true, if: ->(form) { form.category_id.present? }
+      validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
+      validates :scope_id, scope_belongs_to_component: true, if: ->(form) { form.scope_id.present? }
+      validate :notify_missing_attachment_if_errored
+
+      delegate :categories, to: :current_component
+
+      def map_model(model)
+        super
+
+        body = translated_attribute(model.body)
+        @suggested_hashtags = Decidim::ContentRenderers::HashtagRenderer.new(body).extra_hashtags.map(&:name).map(&:downcase)
+
+        # The scope attribute is with different key (decidim_scope_id), so it
+        # has to be manually mapped.
+        self.scope_id = model.scope.id if model.scope
+      end
+
+      # Finds the Category from the category_id.
+      #
+      # Returns a Decidim::Category
+      def category
+        @category ||= categories.find_by(id: category_id)
+      end
+
+      # Finds the Scope from the given scope_id, uses participatory space scope if missing.
+      #
+      # Returns a Decidim::Scope
+      def scope
+        @scope ||= @scope_id ? current_component.scopes.find_by(id: @scope_id) : current_component.scope
+      end
+
+      # Scope identifier
+      #
+      # Returns the scope identifier related to the proposal
+      def scope_id
+        @scope_id || scope&.id
+      end
+
+      def geocoding_enabled?
+        Decidim::Map.available?(:geocoding) && current_component.settings.geocoding_enabled?
+      end
+
+      def has_address?
+        geocoding_enabled? && address.present?
+      end
+
+      def geocoded?
+        latitude.present? && longitude.present?
+      end
+
+      def extra_hashtags
+        @extra_hashtags ||= (component_automatic_hashtags + suggested_hashtags).uniq
+      end
+
+      def suggested_hashtags
+        downcased_suggested_hashtags = Array(@suggested_hashtags&.map(&:downcase)).to_set
+        component_suggested_hashtags.select { |hashtag| downcased_suggested_hashtags.member?(hashtag.downcase) }
+      end
+
+      def suggested_hashtag_checked?(hashtag)
+        suggested_hashtags.member?(hashtag)
+      end
+
+      def component_automatic_hashtags
+        @component_automatic_hashtags ||= ordered_hashtag_list(current_component.current_settings.automatic_hashtags)
+      end
+
+      def component_suggested_hashtags
+        @component_suggested_hashtags ||= ordered_hashtag_list(current_component.current_settings.suggested_hashtags)
+      end
+
+      private
+
+      # This method will add an error to the `attachment` field only if there's
+      # any error in any other field. This is needed because when the form has
+      # an error, the attachment is lost, so we need a way to inform the user of
+      # this problem.
+      def notify_missing_attachment_if_errored
+        errors.add(:attachment, :needs_to_be_reattached) if errors.any? && attachment.present?
+      end
+
+      def ordered_hashtag_list(string)
+        string.to_s.split.reject(&:blank?).uniq.sort_by(&:parameterize)
+      end
+    end
+  end
+end

--- a/app/views/decidim/proposals/collaborative_drafts/_edit_form_fields.html.erb
+++ b/app/views/decidim/proposals/collaborative_drafts/_edit_form_fields.html.erb
@@ -1,0 +1,83 @@
+<%= form_required_explanation %>
+
+<div class="field hashtags__container">
+  <%= form.text_field :title, class: "js-hashtags", value: form_presenter.title %>
+</div>
+
+<div class="field hashtags__container">
+  <%= form.text_area :body, rows: 10, class: "js-hashtags", value: form_presenter.body(extras: false).strip %>
+</div>
+
+<% if @form.component_automatic_hashtags.any? %>
+  <div class="field">
+    <%= form.label :automatic_hashtags %>
+    <div class="checkboxes hashtags">
+      <% @form.component_automatic_hashtags.each do |hashtag| %>
+        <label>
+          <%= check_box_tag "", "", { checked: true }, { disabled: true } %>#<%= hashtag %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @form.component_suggested_hashtags.any? %>
+  <div class="field">
+    <%= form.label :suggested_hashtags, nil, for: nil %>
+    <div class="checkboxes hashtags">
+      <%= form.collection_check_boxes :suggested_hashtags, @form.component_suggested_hashtags.map {|hashtag| [hashtag.downcase, "##{hashtag}"]}, :first, :last do |option|
+        option.label { option.check_box(checked: @form.suggested_hashtag_checked?(option.value)) + option.text }
+      end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @form.geocoding_enabled? %>
+  <div class="field">
+    <%= form.check_box :has_address, checked: form_has_address? %>
+  </div>
+
+  <div class="field" id="address_input">
+    <%= form.geocoding_field :address %>
+  </div>
+<% end %>
+
+<% if @form.categories&.any? %>
+  <div class="field">
+    <%= form.categories_select :category_id, @form.categories, include_blank: t("decidim.proposals.collaborative_drafts.edit.select_a_category") %>
+  </div>
+<% end %>
+
+<% if current_component.has_subscopes? %>
+  <div class="field">
+    <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  </div>
+<% end %>
+
+<% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+  <div class="field">
+    <%= user_group_select_field form, :user_group_id %>
+  </div>
+<% end %>
+
+<% if component_settings.attachments_allowed? %>
+  <fieldset>
+    <legend><%= t("attachment_legend", scope: "decidim.proposals.collaborative_drafts.edit") %></legend>
+    <%= form.fields_for :attachment, @form.attachment do |nested_form| %>
+      <div class="field">
+        <%= nested_form.text_field :title %>
+      </div>
+
+      <div class="field">
+        <%= nested_form.upload :file, optional: false %>
+        <% if @form.errors[:attachment].present? %>
+          <% @form.errors[:attachment].each do |message| %>
+            <small class="form-error is-visible">
+              <%= message %>
+            </small>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </fieldset>
+<% end %>

--- a/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -1,0 +1,111 @@
+<%= form_required_explanation %>
+
+<div class="field hashtags__container">
+  <%= form.text_field :title, class: "js-hashtags", value: form_presenter.title %>
+</div>
+
+<div class="field hashtags__container">
+  <%= text_editor_for_proposal_body(form) %>
+</div>
+
+<% if @form.component_automatic_hashtags.any? %>
+  <div class="field">
+    <%= form.label :automatic_hashtags %>
+    <div class="checkboxes hashtags">
+      <% @form.component_automatic_hashtags.each do |hashtag| %>
+        <label>
+          <%= check_box_tag "", "", { checked: true }, { disabled: true } %>#<%= hashtag %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @form.component_suggested_hashtags.any? %>
+  <div class="field">
+    <%= form.label :suggested_hashtags, nil, for: nil %>
+    <div class="checkboxes hashtags">
+      <%= form.collection_check_boxes :suggested_hashtags, @form.component_suggested_hashtags.map { |hashtag| [hashtag.downcase, "##{hashtag}"] }, :first, :last do |option|
+        option.label { option.check_box(checked: @form.suggested_hashtag_checked?(option.value)) + option.text }
+      end %>
+    </div>
+  </div>
+<% end %>
+
+<% if @form.geocoding_enabled? %>
+  <div class="field">
+    <%= form.check_box :has_address, checked: form_has_address? %>
+  </div>
+
+  <div class="field" id="address_input">
+    <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address") %>
+  </div>
+<% end %>
+
+<% if @form.categories&.any? %>
+  <div class="field">
+    <%= form.categories_select :category_id, @form.categories, include_blank: t("decidim.proposals.proposals.edit.select_a_category") %>
+  </div>
+<% end %>
+
+<% if current_component.has_subscopes? %>
+  <div class="field">
+    <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  </div>
+<% end %>
+
+<% if current_organization.user_groups_enabled? && Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+  <div class="field">
+    <%= user_group_select_field form, :user_group_id %>
+  </div>
+<% end %>
+
+<% if component_settings.attachments_allowed? && @proposal %>
+  <fieldset class="gallery__container">
+    <legend><%= t("gallery_legend", scope: "decidim.proposals.proposals.edit") %></legend>
+
+    <% if @form.photos.any? %>
+      <% @form.photos.each do |photo| %>
+        <div class="callout gallery__item" id="attachment_<%= photo.id %>" data-closable>
+          <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.file.filename %>
+          <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
+                  title="<%= t("delete_image", scope: "decidim.proposals.proposals.edit") %>"
+                  type="button"
+                  data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="row column">
+      <%= form.file_field :add_photos, multiple: false, label: t("add_images", scope: "decidim.proposals.proposals.edit") %>
+    </div>
+  </fieldset>
+
+  <fieldset class="gallery__container">
+    <legend><%= t("attachment_legend", scope: "decidim.proposals.proposals.edit") %></legend>
+
+    <% if @form.documents.any? %>
+      <% @form.documents.each do |document| %>
+        <div class="callout" id="attachment_<%= document.id %>" data-closable>
+          <%= link_to translated_attribute(document.title), document.url %>
+          <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
+          <%= form.hidden_field :documents, multiple: true, value: document.id, id: "document-#{document.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_document", scope: "decidim.proposals.proposals.edit") %>"
+                  title="<%= t("delete_document", scope: "decidim.proposals.proposals.edit") %>"
+                  type="button" data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="row column">
+      <%= form.file_field :add_documents, multiple: true, label: t("add_documents", scope: "decidim.proposals.proposals.edit") %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -62,7 +62,7 @@
 
 <% if component_settings.attachments_allowed? && @proposal %>
   <fieldset class="gallery__container">
-    <legend><%= t("gallery_legend", scope: "decidim.proposals.proposals.edit") %></legend>
+    <legend><%= raw t("gallery_legend", scope: "decidim.proposals.proposals.edit") %></legend>
 
     <% if @form.photos.any? %>
       <% @form.photos.each do |photo| %>

--- a/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -32,16 +32,6 @@
   </div>
 <% end %>
 
-<% if @form.geocoding_enabled? %>
-  <div class="field">
-    <%= form.check_box :has_address, checked: form_has_address? %>
-  </div>
-
-  <div class="field" id="address_input">
-    <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address") %>
-  </div>
-<% end %>
-
 <% if @form.categories&.any? %>
   <div class="field">
     <%= form.categories_select :category_id, @form.categories, include_blank: t("decidim.proposals.proposals.edit.select_a_category") %>
@@ -51,6 +41,12 @@
 <% if current_component.has_subscopes? %>
   <div class="field">
     <%= scopes_picker_field form, :scope_id, root: current_component.scope %>
+  </div>
+<% end %>
+
+<% if @form.geocoding_enabled? %>
+  <div class="field" id="address_input">
+    <%= form.geocoding_field :address, placeholder: t("decidim.proposals.proposals.placeholder.address") %>
   </div>
 <% end %>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -88,6 +88,18 @@ ignore_missing:
  - decidim.endorsable.endorsements
  - decidim.proposals.proposals.votes_count.most_popular_proposal
  - decidim.proposals.proposals.votes_count.need_more_votes
+ - decidim.proposals.proposals.edit.select_a_category
+ - decidim.proposals.proposals.edit.delete_image
+ - decidim.proposals.proposals.edit.add_images
+ - decidim.proposals.proposals.edit.attachment_legend
+ - decidim.proposals.proposals.edit.delete_document
+ - decidim.proposals.proposals.edit.add_documents
+ - decidim.proposals.proposals.placeholder.address
+ - decidim.proposals.collaborative_drafts.edit.select_a_category
+ - decidim.proposals.collaborative_drafts.edit.attachment_legend
+ - activemodel.attributes.proposal.address
+
+
 
 
 # Consider these keys used:
@@ -103,3 +115,4 @@ ignore_unused:
   - decidim.verifications.authorizations.first_login.actions.osp_authorization_handler
   - decidim.verifications.authorizations.first_login.actions.osp_authorization_workflow
   - layouts.decidim.user_menu.account
+  - activemodel.attributes.proposal.address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,10 +61,10 @@ en:
         error: There was a problem deleting the collaborative draft.
         success: Proposal draft was successfully deleted.
       proposals:
-        edit:
-          gallery_legend: "(Optional) Add an image to the proposal card. <br> <b><em>Note: You must be owner of the image</em></b>"
         compare:
           no_similars_found: Well done! No similar proposals found
+        edit:
+          gallery_legend: "(Optional) Add an image to the proposal card. <br> <b><em>Note: You must be owner of the image</em></b>"
       publish:
         error: There was a problem publishing the proposal.
         success: Proposal successfully published.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,8 @@ en:
         error: There was a problem deleting the collaborative draft.
         success: Proposal draft was successfully deleted.
       proposals:
+        edit:
+          gallery_legend: "(Optional) Add an image to the proposal card. <br> <b><em>Note: You must be owner of the image</em></b>"
         compare:
           no_similars_found: Well done! No similar proposals found
       publish:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,14 +2,14 @@
 fr:
   activemodel:
     attributes:
-      proposal:
-        address: Adresse précise (facultatif)
       osp_authorization_handler:
         birthday: Date de naissance
         document_number: Numéro unique
         postal_code: Code postal
       participatory_process:
         private_space: Espace privé
+      proposal:
+        address: Adresse précise (facultatif)
   decidim:
     accessibility:
       skip_button: Passer au contenu principal
@@ -63,10 +63,10 @@ fr:
         error: Des erreurs sont survenues lors de la suppression du brouillon de la proposition.
         success: Le brouillon de la proposition a bien été supprimé.
       proposals:
-        edit:
-          gallery_legend: "(Facultatif) Ajouter une image à la carte de proposition. <br> <em>Attention : le déposant s’engage à posséder les droits de diffusion de l’image</em>"
         compare:
           no_similars_found: Bien joué ! Aucune proposition similaire n'a été trouvée
+        edit:
+          gallery_legend: "(Facultatif) Ajouter une image à la carte de proposition. <br> <em>Attention : le déposant s’engage à posséder les droits de diffusion de l’image</em>"
       publish:
         error: Il y a eu des erreurs lors de la publication de la proposition.
         success: Proposition publiée avec succès.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,8 @@
 fr:
   activemodel:
     attributes:
+      proposal:
+        address: Adresse précise (facultatif)
       osp_authorization_handler:
         birthday: Date de naissance
         document_number: Numéro unique
@@ -61,6 +63,8 @@ fr:
         error: Des erreurs sont survenues lors de la suppression du brouillon de la proposition.
         success: Le brouillon de la proposition a bien été supprimé.
       proposals:
+        edit:
+          gallery_legend: "(Facultatif) Ajouter une image à la carte de proposition. <br> <em>Attention : le déposant s’engage à posséder les droits de diffusion de l’image</em>"
         compare:
           no_similars_found: Bien joué ! Aucune proposition similaire n'a été trouvée
       publish:

--- a/spec/forms/decidim/proposals/proposal_form_spec.rb
+++ b/spec/forms/decidim/proposals/proposal_form_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalForm do
+      let(:params) do
+        super.merge(
+          user_group_id: user_group_id
+        )
+      end
+
+      it_behaves_like "a proposal form", user_group_check: true, i18n: false
+    end
+  end
+end

--- a/spec/shared/proposal_form_examples.rb
+++ b/spec/shared/proposal_form_examples.rb
@@ -1,0 +1,413 @@
+# frozen_string_literal: true
+
+shared_examples "a proposal form" do |options|
+  subject { form }
+
+  let(:organization) { create(:organization, available_locales: [:en]) }
+  let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
+  let(:component) { create(:proposal_component, participatory_space: participatory_space) }
+  let(:title) do
+    if options[:i18n] == false
+      "More sidewalks and less roads!"
+    else
+      { en: "More sidewalks and less roads!" }
+    end
+  end
+  let(:body) do
+    if options[:i18n] == false
+      "Everything would be better"
+    else
+      { en: "Everything would be better" }
+    end
+  end
+  let(:author) { create(:user, organization: organization) }
+  let(:user_group) { create(:user_group, :verified, users: [author], organization: organization) }
+  let(:user_group_id) { user_group.id }
+  let(:category) { create(:category, participatory_space: participatory_space) }
+  let(:parent_scope) { create(:scope, organization: organization) }
+  let(:scope) { create(:subscope, parent: parent_scope) }
+  let(:category_id) { category.try(:id) }
+  let(:scope_id) { scope.try(:id) }
+  let(:latitude) { 40.1234 }
+  let(:longitude) { 2.1234 }
+  let(:address) { nil }
+  let(:suggested_hashtags) { [] }
+  let(:attachment_params) { nil }
+  let(:meeting_as_author) { false }
+  let(:params) do
+    {
+      title: title,
+      body: body,
+      author: author,
+      category_id: category_id,
+      scope_id: scope_id,
+      address: address,
+      meeting_as_author: meeting_as_author,
+      attachment: attachment_params,
+      suggested_hashtags: suggested_hashtags
+    }
+  end
+
+  let(:form) do
+    described_class.from_params(params).with_context(
+      current_component: component,
+      current_organization: component.organization,
+      current_participatory_space: participatory_space
+    )
+  end
+
+  describe "scope" do
+    let(:current_component) { component }
+
+    it_behaves_like "a scopable resource"
+  end
+
+  context "when everything is OK" do
+    it { is_expected.to be_valid }
+  end
+
+  context "when there's no title" do
+    let(:title) { nil }
+
+    it { is_expected.to be_invalid }
+
+    it "only adds errors to this field" do
+      subject.valid?
+      if options[:i18n]
+        expect(subject.errors.keys).to eq [:title_en]
+      else
+        expect(subject.errors.keys).to eq [:title]
+      end
+    end
+  end
+
+  context "when the title is too long" do
+    let(:title) do
+      if options[:i18n] == false
+        "A" * 200
+      else
+        { en: "A" * 200 }
+      end
+    end
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when the title is the minimum length" do
+    let(:title) do
+      if options[:i18n] == false
+        "Length is right"
+      else
+        { en: "Length is right" }
+      end
+    end
+
+    it { is_expected.to be_valid }
+  end
+
+  unless options[:skip_etiquette_validation]
+    context "when the body is not etiquette-compliant" do
+      let(:body) do
+        if options[:i18n] == false
+          "A"
+        else
+          { en: "A" }
+        end
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  context "when there's no body" do
+    let(:body) { nil }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when no category_id" do
+    let(:category_id) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when no scope_id" do
+    let(:scope_id) { nil }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "with invalid category_id" do
+    let(:category_id) { 987 }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when geocoding is enabled" do
+    let(:component) { create(:proposal_component, :with_geocoding_enabled, participatory_space: participatory_space) }
+
+    context "when the has address checkbox is checked" do
+      context "when the address is not present" do
+        it "does not store the coordinates" do
+          expect(subject).to be_valid
+          expect(subject.address).to be(nil)
+          expect(subject.latitude).to be(nil)
+          expect(subject.longitude).to be(nil)
+        end
+      end
+
+      context "when the address is present" do
+        let(:address) { "Some address" }
+
+        before do
+          stub_geocoding(address, [latitude, longitude])
+        end
+
+        it "validates the address and store its coordinates" do
+          expect(subject).to be_valid
+          expect(subject.latitude).to eq(latitude)
+          expect(subject.longitude).to eq(longitude)
+        end
+      end
+    end
+
+    context "when latitude and longitude are manually set" do
+      context "when the has address checkbox is unchecked" do
+        it "is valid" do
+          expect(subject).to be_valid
+          expect(subject.latitude).to eq(nil)
+          expect(subject.longitude).to eq(nil)
+        end
+      end
+
+      context "when the proposal is unchanged" do
+        let(:previous_proposal) { create(:proposal, address: address) }
+
+        let(:title) do
+          if options[:skip_etiquette_validation]
+            previous_proposal.title
+          else
+            translated(previous_proposal.title)
+          end
+        end
+
+        let(:body) do
+          if options[:skip_etiquette_validation]
+            previous_proposal.body
+          else
+            translated(previous_proposal.body)
+          end
+        end
+
+        let(:params) do
+          {
+            id: previous_proposal.id,
+            title: title,
+            body: body,
+            author: previous_proposal.authors.first,
+            category_id: previous_proposal.try(:category_id),
+            scope_id: previous_proposal.try(:scope_id),
+            address: address,
+            attachment: previous_proposal.try(:attachment_params),
+            latitude: latitude,
+            longitude: longitude
+          }
+        end
+
+        it "is valid" do
+          expect(subject).to be_valid
+          expect(subject.latitude).to eq(latitude)
+          expect(subject.longitude).to eq(longitude)
+        end
+      end
+    end
+  end
+
+  describe "category" do
+    subject { form.category }
+
+    context "when the category exists" do
+      it { is_expected.to be_kind_of(Decidim::Category) }
+    end
+
+    context "when the category does not exist" do
+      let(:category_id) { 7654 }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context "when the category is from another process" do
+      let(:category_id) { create(:category).id }
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+
+  it "properly maps category id from model" do
+    proposal = create(:proposal, component: component, category: category)
+
+    expect(described_class.from_model(proposal).category_id).to eq(category_id)
+  end
+
+  if options && options[:user_group_check]
+    it "properly maps user group id from model" do
+      proposal = create(:proposal, component: component, users: [author], user_groups: [user_group])
+
+      expect(described_class.from_model(proposal).user_group_id).to eq(user_group_id)
+    end
+  end
+
+  context "when the attachment is present" do
+    let(:attachment_params) do
+      {
+        title: "My attachment",
+        file: Decidim::Dev.test_file("city.jpeg", "image/jpeg")
+      }
+    end
+
+    it { is_expected.to be_valid }
+
+    context "when the form has some errors" do
+      let(:title) { nil }
+
+      it "adds an error to the `:attachment` field" do
+        expect(subject).not_to be_valid
+
+        if options[:i18n]
+          expect(subject.errors.full_messages).to match_array(["Title en can't be blank", "Attachment Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title_en, :attachment])
+        else
+          expect(subject.errors.full_messages).to match_array(["Title can't be blank", "Title is too short (under 15 characters)", "Attachment Needs to be reattached"])
+          expect(subject.errors.keys).to match_array([:title, :attachment])
+        end
+      end
+    end
+  end
+
+  describe "#extra_hashtags" do
+    subject { form.extra_hashtags }
+
+    let(:component) do
+      create(
+        :proposal_component,
+        :with_extra_hashtags,
+        participatory_space: participatory_space,
+        suggested_hashtags: component_suggested_hashtags,
+        automatic_hashtags: component_automatic_hashtags
+      )
+    end
+    let(:component_automatic_hashtags) { "" }
+    let(:component_suggested_hashtags) { "" }
+
+    it { is_expected.to eq([]) }
+
+    context "when there are auto hashtags" do
+      let(:component_automatic_hashtags) { "HashtagAuto1 HashtagAuto2" }
+
+      it { is_expected.to eq(%w(HashtagAuto1 HashtagAuto2)) }
+    end
+
+    context "when there are some suggested hashtags checked" do
+      let(:component_suggested_hashtags) { "HashtagSuggested1 HashtagSuggested2 HashtagSuggested3" }
+      let(:suggested_hashtags) { %w(HashtagSuggested1 HashtagSuggested2) }
+
+      it { is_expected.to eq(%w(HashtagSuggested1 HashtagSuggested2)) }
+    end
+
+    context "when there are invalid suggested hashtags checked" do
+      let(:component_suggested_hashtags) { "HashtagSuggested1 HashtagSuggested2" }
+      let(:suggested_hashtags) { %w(HashtagSuggested1 HashtagSuggested3) }
+
+      it { is_expected.to eq(%w(HashtagSuggested1)) }
+    end
+
+    context "when there are both suggested and auto hashtags" do
+      let(:component_automatic_hashtags) { "HashtagAuto1 HashtagAuto2" }
+      let(:component_suggested_hashtags) { "HashtagSuggested1 HashtagSuggested2" }
+      let(:suggested_hashtags) { %w(HashtagSuggested2) }
+
+      it { is_expected.to eq(%w(HashtagAuto1 HashtagAuto2 HashtagSuggested2)) }
+    end
+  end
+end
+
+shared_examples "a proposal form with meeting as author" do |options|
+  subject { form }
+
+  let(:organization) { create(:organization, available_locales: [:en]) }
+  let(:participatory_space) { create(:participatory_process, :with_steps, organization: organization) }
+  let(:component) { create(:proposal_component, participatory_space: participatory_space) }
+  let(:title) { { en: "More sidewalks and less roads!" } }
+  let(:body) { { en: "Everything would be better" } }
+  let(:created_in_meeting) { true }
+  let(:meeting_component) { create(:meeting_component, participatory_space: participatory_space) }
+  let(:author) { create(:meeting, component: meeting_component) }
+  let!(:meeting_as_author) { author }
+
+  let(:params) do
+    {
+      title: title,
+      body: body,
+      created_in_meeting: created_in_meeting,
+      author: meeting_as_author,
+      meeting_id: author.id
+    }
+  end
+
+  let(:form) do
+    described_class.from_params(params).with_context(
+      current_component: component,
+      current_organization: component.organization,
+      current_participatory_space: participatory_space
+    )
+  end
+
+  context "when everything is OK" do
+    it { is_expected.to be_valid }
+  end
+
+  context "when there's no title" do
+    let(:title) { nil }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when the title is too long" do
+    let(:title) do
+      if options[:i18n] == false
+        "A" * 200
+      else
+        { en: "A" * 200 }
+      end
+    end
+
+    it { is_expected.to be_invalid }
+  end
+
+  unless options[:skip_etiquette_validation]
+    context "when the body is not etiquette-compliant" do
+      let(:body) do
+        if options[:i18n] == false
+          "A"
+        else
+          { en: "A" }
+        end
+      end
+
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  context "when there's no body" do
+    let(:body) { nil }
+
+    it { is_expected.to be_invalid }
+  end
+
+  context "when proposals comes from a meeting" do
+    it "validates the meeting as author" do
+      expect(subject).to be_valid
+      expect(subject.author).to eq(author)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,5 +23,9 @@ RSpec.configure do |config|
     SocialShareButton.configure do |social_share_button|
       social_share_button.allow_sites = %w(twitter facebook whatsapp_app whatsapp_web telegram)
     end
+
+    Decidim::Verifications.register_workflow(:dummy_authorization_handler) do |auth|
+      auth.form = "DummyAuthorizationHandler"
+    end
   end
 end

--- a/spec/system/proposal_fields_spec.rb
+++ b/spec/system/proposal_fields_spec.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Proposals", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "proposals" }
+
+  let!(:category) { create :category, participatory_space: participatory_process }
+  let!(:scope) { create :scope, organization: organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
+  let(:scoped_participatory_process) { create(:participatory_process, :with_steps, organization: organization, scope: scope) }
+
+  let(:address) { "Some address" }
+  let(:latitude) { 40.1234 }
+  let(:longitude) { 2.1234 }
+
+  let(:proposal_title) { "More sidewalks and less roads" }
+  let(:proposal_body) { "Cities need more people, not more cars" }
+
+  before do
+    stub_geocoding(address, [latitude, longitude])
+  end
+
+  matcher :have_author do |name|
+    match { |node| node.has_selector?(".author-data", text: name) }
+    match_when_negated { |node| node.has_no_selector?(".author-data", text: name) }
+  end
+
+  context "when creating a new proposal" do
+    let(:scope_picker) { select_data_picker(:proposal_scope_id) }
+
+    context "when the user is logged in" do
+      before do
+        login_as user, scope: :user
+      end
+
+      context "with creation enabled" do
+        let!(:component) do
+          create(:proposal_component,
+                 :with_creation_enabled,
+                 manifest: manifest,
+                 participatory_space: participatory_process,
+                 settings: { scopes_enabled: true, scope_id: participatory_process.scope&.id })
+        end
+
+        let(:proposal_draft) { create(:proposal, :draft, component: component) }
+
+        context "when process is not related to any scope" do
+          it "can be related to a scope" do
+            visit complete_proposal_path(component, proposal_draft)
+
+            within "form.edit_proposal" do
+              expect(page).to have_content(/Scope/i)
+            end
+          end
+        end
+
+        context "when process is related to a leaf scope" do
+          let(:participatory_process) { scoped_participatory_process }
+
+          it "cannot be related to a scope" do
+            visit complete_proposal_path(component, proposal_draft)
+
+            within "form.edit_proposal" do
+              expect(page).to have_no_content("Scope")
+            end
+          end
+        end
+
+        it "creates a new proposal", :slow do
+          visit complete_proposal_path(component, proposal_draft)
+
+          within ".edit_proposal" do
+            fill_in :proposal_title, with: "More sidewalks and less roads"
+            fill_in :proposal_body, with: "Cities need more people, not more cars"
+            select translated(category.name), from: :proposal_category_id
+            scope_pick scope_picker, scope
+
+            find("*[type=submit]").click
+          end
+
+          click_button "Publish"
+
+          expect(page).to have_content("successfully")
+          expect(page).to have_content("More sidewalks and less roads")
+          expect(page).to have_content("Cities need more people, not more cars")
+          expect(page).to have_content(translated(category.name))
+          expect(page).to have_content(translated(scope.name))
+          expect(page).to have_author(user.name)
+        end
+
+        context "when geocoding is enabled", :serves_map, :serves_geocoding_autocomplete do
+          let!(:component) do
+            create(:proposal_component,
+                   :with_creation_enabled,
+                   manifest: manifest,
+                   participatory_space: participatory_process,
+                   settings: {
+                     geocoding_enabled: true,
+                     scopes_enabled: true,
+                     scope_id: participatory_process.scope&.id
+                   })
+          end
+
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+
+          it "creates a new proposal", :slow do
+            visit complete_proposal_path(component, proposal_draft)
+
+            within ".edit_proposal" do
+              check :proposal_has_address
+              fill_in :proposal_title, with: "More sidewalks and less roads"
+              fill_in :proposal_body, with: "Cities need more people, not more cars"
+              fill_in_geocoding :proposal_address, with: address
+              select translated(category.name), from: :proposal_category_id
+              scope_pick scope_picker, scope
+
+              find("*[type=submit]").click
+            end
+
+            click_button "Publish"
+
+            expect(page).to have_content("successfully")
+            expect(page).to have_content("More sidewalks and less roads")
+            expect(page).to have_content("Cities need more people, not more cars")
+            expect(page).to have_content(address)
+            expect(page).to have_content(translated(category.name))
+            expect(page).to have_content(translated(scope.name))
+            expect(page).to have_author(user.name)
+          end
+
+          it_behaves_like(
+            "a record with front-end geocoding address field",
+            Decidim::Proposals::Proposal,
+            within_selector: ".edit_proposal",
+            address_field: :proposal_address
+          ) do
+            let(:geocoded_record) { proposal_draft }
+            let(:geocoded_address_value) { address }
+            let(:geocoded_address_coordinates) { [latitude, longitude] }
+
+            before do
+              # Prepare the view for submission (other than the address field)
+              visit complete_proposal_path(component, proposal_draft)
+
+              check :proposal_has_address
+              fill_in :proposal_title, with: "More sidewalks and less roads"
+              fill_in :proposal_body, with: "Cities need more people, not more cars"
+            end
+          end
+        end
+
+        context "when component has extra hashtags defined" do
+          let(:component) do
+            create(:proposal_component,
+                   :with_extra_hashtags,
+                   suggested_hashtags: component_suggested_hashtags,
+                   automatic_hashtags: component_automatic_hashtags,
+                   manifest: manifest,
+                   participatory_space: participatory_process)
+          end
+
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+          let(:component_automatic_hashtags) { "AutoHashtag1 AutoHashtag2" }
+          let(:component_suggested_hashtags) { "SuggestedHashtag1 SuggestedHashtag2" }
+
+          it "offers and save extra hashtags", :slow do
+            visit complete_proposal_path(component, proposal_draft)
+
+            within ".edit_proposal" do
+              check :proposal_suggested_hashtags_suggestedhashtag1
+
+              find("*[type=submit]").click
+            end
+
+            click_button "Publish"
+
+            expect(page).to have_content("successfully")
+            expect(page).to have_content("#AutoHashtag1")
+            expect(page).to have_content("#AutoHashtag2")
+            expect(page).to have_content("#SuggestedHashtag1")
+            expect(page).not_to have_content("#SuggestedHashtag2")
+          end
+        end
+
+        context "when the user has verified organizations" do
+          let(:user_group) { create(:user_group, :verified, organization: organization) }
+          let(:user_group_proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "Cities need more people, not more cars") }
+
+          before do
+            create(:user_group_membership, user: user, user_group: user_group)
+          end
+
+          it "creates a new proposal as a user group", :slow do
+            visit complete_proposal_path(component, user_group_proposal_draft)
+
+            within ".edit_proposal" do
+              fill_in :proposal_title, with: "More sidewalks and less roads"
+              fill_in :proposal_body, with: "Cities need more people, not more cars"
+              select translated(category.name), from: :proposal_category_id
+              scope_pick scope_picker, scope
+              select user_group.name, from: :proposal_user_group_id
+
+              find("*[type=submit]").click
+            end
+
+            click_button "Publish"
+
+            expect(page).to have_content("successfully")
+            expect(page).to have_content("More sidewalks and less roads")
+            expect(page).to have_content("Cities need more people, not more cars")
+            expect(page).to have_content(translated(category.name))
+            expect(page).to have_content(translated(scope.name))
+            expect(page).to have_author(user_group.name)
+          end
+
+          context "when geocoding is enabled", :serves_map, :serves_geocoding_autocomplete do
+            let!(:component) do
+              create(:proposal_component,
+                     :with_creation_enabled,
+                     manifest: manifest,
+                     participatory_space: participatory_process,
+                     settings: {
+                       geocoding_enabled: true,
+                       scopes_enabled: true,
+                       scope_id: participatory_process.scope&.id
+                     })
+            end
+
+            let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "More sidewalks and less roads", body: "He will not solve everything") }
+
+            it "creates a new proposal as a user group", :slow do
+              visit complete_proposal_path(component, proposal_draft)
+
+              within ".edit_proposal" do
+                fill_in :proposal_title, with: "More sidewalks and less roads"
+                fill_in :proposal_body, with: "Cities need more people, not more cars"
+                check :proposal_has_address
+                fill_in :proposal_address, with: address
+                select translated(category.name), from: :proposal_category_id
+                scope_pick scope_picker, scope
+                select user_group.name, from: :proposal_user_group_id
+
+                find("*[type=submit]").click
+              end
+
+              click_button "Publish"
+
+              expect(page).to have_content("successfully")
+              expect(page).to have_content("More sidewalks and less roads")
+              expect(page).to have_content("Cities need more people, not more cars")
+              expect(page).to have_content(address)
+              expect(page).to have_content(translated(category.name))
+              expect(page).to have_content(translated(scope.name))
+              expect(page).to have_author(user_group.name)
+            end
+          end
+        end
+
+        context "when the user isn't authorized" do
+          before do
+            permissions = {
+              create: {
+                authorization_handlers: {
+                  "dummy_authorization_handler" => { "options" => {} }
+                }
+              }
+            }
+
+            component.update!(permissions: permissions)
+          end
+
+          it "shows a modal dialog" do
+            visit_component
+            click_link "New proposal"
+            expect(page).to have_content("Authorization required")
+          end
+        end
+
+        context "when attachments are allowed", processing_uploads_for: Decidim::AttachmentUploader do
+          let!(:component) do
+            create(:proposal_component,
+                   :with_creation_enabled,
+                   :with_attachments_allowed,
+                   manifest: manifest,
+                   participatory_space: participatory_process)
+          end
+
+          let(:proposal_draft) { create(:proposal, :draft, users: [user], component: component, title: "Proposal with attachments", body: "This is my proposal and I want to upload attachments.") }
+
+          it "creates a new proposal with attachments" do
+            visit complete_proposal_path(component, proposal_draft)
+
+            within ".edit_proposal" do
+              fill_in :proposal_title, with: "Proposal with attachments"
+              fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
+              attach_file :proposal_add_photos, Decidim::Dev.asset("city.jpeg")
+              find("*[type=submit]").click
+            end
+
+            click_button "Publish"
+
+            expect(page).to have_content("successfully")
+
+            within ".section.images" do
+              expect(page).to have_selector("img[src*=\"city.jpeg\"]", count: 1)
+            end
+          end
+        end
+      end
+
+      context "when creation is not enabled" do
+        it "does not show the creation button" do
+          visit_component
+          expect(page).to have_no_link("New proposal")
+        end
+      end
+
+      context "when the proposal limit is 1" do
+        let!(:component) do
+          create(:proposal_component,
+                 :with_creation_enabled,
+                 :with_proposal_limit,
+                 manifest: manifest,
+                 participatory_space: participatory_process)
+        end
+
+        let!(:proposal_first) { create(:proposal, users: [user], component: component, title: "Creating my first and only proposal", body: "This is my only proposal's body and I'm using it unwisely.") }
+
+        before do
+          visit_component
+          click_link "New proposal"
+        end
+
+        it "allows the creation of a single new proposal" do
+          within ".new_proposal" do
+            fill_in :proposal_title, with: "Creating my second proposal"
+            fill_in :proposal_body, with: "This is my second proposal's body and I'm using it unwisely."
+
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_no_content("successfully")
+          expect(page).to have_css(".callout.alert", text: "limit")
+        end
+      end
+    end
+  end
+end
+
+def complete_proposal_path(component, proposal)
+  "#{Decidim::EngineRouter.main_proxy(component).proposal_path(proposal)}/complete"
+end

--- a/spec/system/proposal_fields_spec.rb
+++ b/spec/system/proposal_fields_spec.rb
@@ -109,7 +109,6 @@ describe "Proposals", type: :system do
             visit complete_proposal_path(component, proposal_draft)
 
             within ".edit_proposal" do
-              check :proposal_has_address
               fill_in :proposal_title, with: "More sidewalks and less roads"
               fill_in :proposal_body, with: "Cities need more people, not more cars"
               fill_in_geocoding :proposal_address, with: address
@@ -295,6 +294,7 @@ describe "Proposals", type: :system do
             within ".edit_proposal" do
               fill_in :proposal_title, with: "Proposal with attachments"
               fill_in :proposal_body, with: "This is my proposal and I want to upload attachments."
+              expect(page).to have_content("(Optional) Add an image to the proposal card.\nNote: You must be owner of the image")
               attach_file :proposal_add_photos, Decidim::Dev.asset("city.jpeg")
               find("*[type=submit]").click
             end

--- a/spec/system/proposal_fields_spec.rb
+++ b/spec/system/proposal_fields_spec.rb
@@ -109,6 +109,7 @@ describe "Proposals", type: :system do
             visit complete_proposal_path(component, proposal_draft)
 
             within ".edit_proposal" do
+              expect(page).not_to have_content("Has address")
               fill_in :proposal_title, with: "More sidewalks and less roads"
               fill_in :proposal_body, with: "Cities need more people, not more cars"
               fill_in_geocoding :proposal_address, with: address
@@ -143,7 +144,6 @@ describe "Proposals", type: :system do
               # Prepare the view for submission (other than the address field)
               visit complete_proposal_path(component, proposal_draft)
 
-              check :proposal_has_address
               fill_in :proposal_title, with: "More sidewalks and less roads"
               fill_in :proposal_body, with: "Cities need more people, not more cars"
             end
@@ -235,7 +235,7 @@ describe "Proposals", type: :system do
               within ".edit_proposal" do
                 fill_in :proposal_title, with: "More sidewalks and less roads"
                 fill_in :proposal_body, with: "Cities need more people, not more cars"
-                check :proposal_has_address
+                expect(page).not_to have_content("Has address")
                 fill_in :proposal_address, with: address
                 select translated(category.name), from: :proposal_category_id
                 scope_pick scope_picker, scope


### PR DESCRIPTION
#### Description

- [x]  Supprimer la coche “renseigner adresse” pour que le champ adresse apparaisse directement.
- [x]  Déplacer le champ adresse sous le champ “localisation” (anciennement “portée”).
- [x]  Renommer le titre du champ adresse :   “adresse précise (facultatif)”
- [x]  Enable HTML sur le texte d’aide à l’ajout d’une image
*Mettre à la ligne et en italique le texte “Attention : le déposant s’engage à posséder les droits de diffusion de l’image”*

#### Screenshot

![Screenshot 2022-02-17 at 15 21 43](https://user-images.githubusercontent.com/26109239/154503072-7cbacb1c-3a7a-45f0-b13c-8cc384827fa0.png)
