### PR TITLE
Fix proposals cells caching

### DIFF
--- a/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -125,9 +125,24 @@ module Decidim
         @resource_image_path ||= has_image? ? model.attachments.find_by("content_type like '%image%'").url : nil
       end
 
-      # Potential backport at https://github.com/decidim/decidim/pull/8566/files
-      def perform_caching?
-        false
+      def cache_hash
+        hash = []
+        hash << "decidim/proposals/proposal_m"
+        hash << I18n.locale.to_s
+        hash << model.cache_key_with_version
+        hash << model.proposal_votes_count
+        hash << model.endorsements_count
+        hash << Digest::MD5.hexdigest(model.component.cache_key_with_version)
+        hash << Digest::MD5.hexdigest(resource_image_path) if resource_image_path
+        if current_user
+          hash << current_user.cache_key_with_version
+          hash << current_user.follows?(model) ? 1 : 0
+        end
+        hash << model.follows_count
+        hash << Digest::MD5.hexdigest(model.authors.map(&:cache_key_with_version).to_s)
+        hash << context[:controller].class
+
+        hash.join("/")
       end
     end
   end


### PR DESCRIPTION
#### Description 

There is a caching troubleshooting when user navigates between participatory process show view and proposals index.

- [x] Add controller context into cache key

#### Testing

Install app locally
`bundle && bundle exec rake test:setup`

Activate cache 
`bundle exec rails dev:cache` (you should have message "Development mode is now being cached.", if not rerun command)

Run application and navigate to the PP show view, highlighted proposals should have a footer with button `view proposal`.
Note the proposals presents in show view, then navigate to proposals index view and search for the proposal in index. 
The card should now have a footer with `supports count`


