### PR TITLE
Skip first login AH

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,9 @@ module DevelopmentApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.after_initialize do
+      require "extends/controllers/decidim/devise/sessions_controller_extends"
+    end
   end
 end

--- a/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
+++ b/lib/extends/controllers/decidim/devise/sessions_controller_extends.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SessionControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def after_sign_in_path_for(user)
+      if user.present? && user.blocked?
+        check_user_block_status(user)
+      elsif !skip_first_login_authorization? && (first_login_and_not_authorized?(user) && !user.admin? && !pending_redirect?(user))
+        decidim_verifications.first_login_authorizations_path
+      else
+        super
+      end
+    end
+
+    private
+
+    # Skip authorization handler by default
+    def skip_first_login_authorization?
+      ActiveRecord::Type::Boolean.new.cast(ENV.fetch("SKIP_FIRST_LOGIN_AUTHORIZATION", "true"))
+    end
+  end
+end
+
+Decidim::Devise::SessionsController.class_eval do
+  include(SessionControllerExtends)
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -35,7 +35,7 @@ module Decidim
                     .and_return(["dummy_authorization_handler"])
                 end
 
-                it { is_expected.to eq("/authorizations/first_login") }
+                it { is_expected.to eq("/") }
 
                 context "when there's a pending redirection" do
                   before do
@@ -66,7 +66,7 @@ module Decidim
                     user.blocked = false
                   end
 
-                  it { is_expected.to eq("/authorizations/first_login") }
+                  it { is_expected.to eq("/") }
                 end
 
                 context "when first login authorization is skipped" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Devise
+    describe SessionsController, type: :controller do
+      routes { Decidim::Core::Engine.routes }
+
+      describe "after_sign_in_path_for" do
+        subject { controller.after_sign_in_path_for(user) }
+
+        before do
+          request.env["decidim.current_organization"] = user.organization
+        end
+
+        context "when the given resource is a user" do
+          context "and is an admin" do
+            let(:user) { build(:user, :admin, sign_in_count: 1) }
+
+            before do
+              controller.store_location_for(user, account_path)
+            end
+
+            it { is_expected.to eq account_path }
+          end
+
+          context "and is not an admin" do
+            context "when it is the first time to log in" do
+              let(:user) { build(:user, :confirmed, sign_in_count: 1) }
+
+              context "when there are authorization handlers" do
+                before do
+                  allow(user.organization).to receive(:available_authorizations)
+                    .and_return(["dummy_authorization_handler"])
+                end
+
+                it { is_expected.to eq("/authorizations/first_login") }
+
+                context "when there's a pending redirection" do
+                  before do
+                    controller.store_location_for(user, account_path)
+                  end
+
+                  it { is_expected.to eq account_path }
+                end
+
+                context "when the user hasn't confirmed their email" do
+                  before do
+                    user.confirmed_at = nil
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
+
+                context "when the user is blocked" do
+                  before do
+                    user.blocked = true
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
+
+                context "when the user is not blocked" do
+                  before do
+                    user.blocked = false
+                  end
+
+                  it { is_expected.to eq("/authorizations/first_login") }
+                end
+
+                context "when first login authorization is skipped" do
+                  before do
+                    ENV["SKIP_FIRST_LOGIN_AUTHORIZATION"] = "true"
+                  end
+
+                  after do
+                    ENV.delete("SKIP_FIRST_LOGIN_AUTHORIZATION")
+                  end
+
+                  it { is_expected.to eq("/") }
+                end
+              end
+
+              context "and otherwise", with_authorization_workflows: [] do
+                before do
+                  allow(user.organization).to receive(:available_authorizations).and_return([])
+                end
+
+                it { is_expected.to eq("/") }
+              end
+            end
+
+            context "and it's not the first time to log in" do
+              let(:user) { build(:user, sign_in_count: 2) }
+
+              it { is_expected.to eq("/") }
+            end
+          end
+        end
+      end
+
+      describe "DELETE destroy" do
+        let(:user) { create(:user, :confirmed) }
+
+        before do
+          request.env["decidim.current_organization"] = user.organization
+          request.env["devise.mapping"] = ::Devise.mappings[:user]
+
+          sign_in user
+        end
+
+        it "clears the current user" do
+          delete :destroy
+
+          expect(controller.current_user).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The goal of this PR is to overload the session controller to make sure the first login AH is not shown to the user on his first login on the platform. 