### PR TITLE
Fix - Order by Most Votes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module DevelopmentApp
 
     config.after_initialize do
       require "extends/controllers/decidim/devise/sessions_controller_extends"
+      require "extends/controllers/decidim/budgets/projects_controller_extends"
     end
   end
 end

--- a/lib/extends/controllers/decidim/budgets/projects_controller_extends.rb
+++ b/lib/extends/controllers/decidim/budgets/projects_controller_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ProjectsControllerExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def projects
+      return @projects if @projects
+
+      @projects = search.results
+      @projects = reorder(@projects)
+      @projects = @projects.page(params[:page]).per(current_component.settings.projects_per_page)
+    end
+  end
+end
+
+Decidim::Budgets::ProjectsController.class_eval do
+  include(ProjectsControllerExtends)
+end

--- a/spec/system/sorting_projects_spec.rb
+++ b/spec/system/sorting_projects_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Sorting projects", type: :system do
+  include_context "with a component"
+  let(:manifest_name) { "budgets" }
+
+  let(:organization) { create :organization }
+  let!(:user) { create :user, :confirmed, organization: organization }
+  let(:project) { projects.first }
+
+  let!(:component) do
+    create(:budgets_component,
+           :with_vote_threshold_percent,
+           manifest: manifest,
+           participatory_space: participatory_process)
+  end
+
+  let(:budget) { create :budget, component: component }
+  let!(:project1) { create(:project, budget: budget, budget_amount: 25_000_000) }
+  let!(:project2) { create(:project, budget: budget, budget_amount: 50_000_000) }
+
+  before do
+    login_as user, scope: :user
+    visit_budget
+  end
+
+  shared_examples "ordering projects by selected option" do |selected_option|
+    before do
+      visit_budget
+      within ".order-by" do
+        expect(page).to have_selector("ul[data-dropdown-menu$=dropdown-menu]", text: "Random order")
+        page.find("a", text: "Random order").click
+        click_link(selected_option)
+      end
+    end
+
+    it "lists the projects ordered by selected option" do
+      # expect(page).to have_selector("#projects li.is-dropdown-submenu-parent a", text: selected_option)
+      within "#projects li.is-dropdown-submenu-parent a" do
+        expect(page).to have_no_content("Random order", wait: 20)
+        expect(page).to have_content(selected_option)
+      end
+
+      expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(first_project.title))
+      expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(last_project.title))
+    end
+  end
+
+  context "when ordering by highest cost" do
+    it_behaves_like "ordering projects by selected option", "Highest cost" do
+      let(:first_project) { project2 }
+      let(:last_project) { project1 }
+    end
+  end
+
+  context "when ordering by lowest cost" do
+    it_behaves_like "ordering projects by selected option", "Lowest cost" do
+      let(:first_project) { project1 }
+      let(:last_project) { project2 }
+    end
+  end
+
+  describe "when the voting is finished" do
+    let!(:component) do
+      create(
+        :budgets_component,
+        :with_voting_finished,
+        manifest: manifest,
+        participatory_space: participatory_process
+      )
+    end
+    let!(:project1) { create(:project, :selected, budget: budget, budget_amount: 25_000_000) }
+    let!(:project2) { create(:project, :selected, budget: budget, budget_amount: 77_000_000) }
+
+    context "when ordering by most votes" do
+      before do
+        order = build :order, budget: budget
+        create :line_item, order: order, project: project2
+        order = Decidim::Budgets::Order.last
+        order.checked_out_at = Time.zone.now
+        order.save
+      end
+
+      it "automatically sorts by votes" do
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:first-child", text: translated(project2.title))
+        expect(page).to have_selector("#projects .budget-list .budget-list__item:last-child", text: translated(project1.title))
+      end
+
+      it "automatically sorts by votes and respect the pagination" do
+        component.update!(settings: { projects_per_page: 1 })
+
+        visit_budget
+
+        within "#projects li.is-dropdown-submenu-parent a" do
+          expect(page).to have_content("Most voted")
+        end
+
+        # project2 on first page
+        expect(page).to have_content(translated(project2.title))
+        expect(page).not_to have_content(translated(project1.title))
+
+        within "#projects .pagination" do
+          expect(page).to have_content("2")
+          page.find("a", text: "2").click
+        end
+
+        # project1 on second page
+        expect(page).not_to have_content(translated(project2.title))
+        expect(page).to have_content(translated(project1.title))
+      end
+    end
+  end
+
+  def visit_budget
+    page.visit Decidim::EngineRouter.main_proxy(component).budget_projects_path(budget)
+  end
+end


### PR DESCRIPTION
#### 🎩 Description

Hello ! I'm submitting to you this Pull request to fix the ordering of budgets' projects by most votes.

Before this PR, we had a bug where our projects weren't well sorted because we had too many projects to sort and so it just didn't work properly, so by now, we just extend a new function that will correct this feature and make sure everything is sorted before we print it and so avoid in the future to have the same issue.

One important point is that we needed to import our extend directly in our application.rb because if we did it in the file that was intended to welcome our extends, Decidim Awesome ends up crashing our app. 

#### 📌 Related Issue

This pull request is linked to this notion card and fixes it :  [Most Votes Issue](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=90abe76cba3c495c92546b1458fa2a2a&p=373e0a34f2cc4939adfec1347860e977&pm=c)

#### Tasks
- [x] Add an extend to our projects controller
- [x] Import this extend into our config/application.rb
- [x] Import specs related to it and fix them


Don't mind bothering me if you have some questions ! 