### PR TITLE
fix: Caching proposal state I18n translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,12 @@ gem "dotenv-rails", require: "dotenv/rails-now"
 
 # Core gems
 gem "decidim", "~> #{DECIDIM_VERSION}.0"
-
 # External Decidim gems
 gem "decidim-cache_cleaner"
 gem "decidim-decidim_awesome"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-spam_detection"
-gem "decidim-term_customizer", git: "https://github.com/armandfardeau/decidim-module-term_customizer.git", branch: "fix/precompile-on-docker-0.26"
+gem "decidim-term_customizer", git: "https://github.com/quentinchampenois/decidim-module-term_customizer.git", branch: "fix/caching_0.26"
 
 # Omniauth gems
 gem "decidim-slider", git: "https://github.com/alecslupu-pfa/decidim-module-slider", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,9 +25,9 @@ GIT
       decidim-core (~> 0.26.0)
 
 GIT
-  remote: https://github.com/armandfardeau/decidim-module-term_customizer.git
-  revision: 63170f69b51bb7e7f60f20856e944ae1357f4dc7
-  branch: fix/precompile-on-docker-0.26
+  remote: https://github.com/quentinchampenois/decidim-module-term_customizer.git
+  revision: e2fd83add45121d032a301c2d3f586a7ac3f699e
+  branch: fix/caching_0.26
   specs:
     decidim-term_customizer (0.26.0)
       decidim-admin (~> 0.26.0)

--- a/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -21,7 +21,7 @@ module Decidim
       end
 
       def title
-        decidim_html_escape(present(model).title)
+        present(model).title(html_escape: true)
       end
 
       def body
@@ -127,8 +127,8 @@ module Decidim
 
       def cache_hash
         hash = []
-        hash << "decidim/proposals/proposal_m"
         hash << I18n.locale.to_s
+        hash << I18n.t(state, scope: "decidim.proposals.answers", default: :not_answered)
         hash << model.cache_key_with_version
         hash << model.proposal_votes_count
         hash << model.endorsements_count

--- a/app/cells/decidim/proposals/proposal_m_cell.rb
+++ b/app/cells/decidim/proposals/proposal_m_cell.rb
@@ -127,6 +127,7 @@ module Decidim
 
       def cache_hash
         hash = []
+        hash << "decidim/proposals/proposal_m"
         hash << I18n.locale.to_s
         hash << I18n.t(state, scope: "decidim.proposals.answers", default: :not_answered)
         hash << model.cache_key_with_version


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

I18n translations changed with Term Customizer does not invalidate the cache_key for proposal cells.

Add I18n translation for state in the proposal cache_key

#### Tasks
- [ ] Add specs
- [x] Update the cache_key for proposals

🚨 Ensure it does not invalidate fix for #16 

