### PR TITLE
fix: Update Rack Attack based on decidim-app

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,4 +6,13 @@ require "decidim_app/rack_attack/fail2ban"
 
 # Enabled by default in production
 # Can be deactivated with 'ENABLE_RACK_ATTACK=0'
-DecidimApp::RackAttack.apply_configuration if DecidimApp::RackAttack.rack_enabled?
+DecidimApp::RackAttack.deactivate_decidim_throttling!
+
+if DecidimApp::RackAttack.rack_enabled?
+  DecidimApp::RackAttack.enable_rack_attack!
+  DecidimApp::RackAttack.apply_configuration
+else
+  DecidimApp::RackAttack.disable_rack_attack!
+end
+
+DecidimApp::RackAttack.info!

--- a/lib/decidim_app/rack_attack.rb
+++ b/lib/decidim_app/rack_attack.rb
@@ -4,21 +4,39 @@ module DecidimApp
   module RackAttack
     def self.rack_enabled?
       setting = Rails.application.secrets.dig(:decidim, :rack_attack, :enabled)
-      return setting == "1" if setting.present?
+      return setting.to_s == "1" if setting.present?
 
       Rails.env.production?
     end
 
-    def self.apply_configuration
-      Rack::Attack.enabled = true
+    def self.info!
+      Rails.logger.info("Rack::Attack is enabled: #{Rack::Attack.enabled}")
+      Rails.logger.info("Rack::Attack Fail2ban is enabled: #{DecidimApp::RackAttack::Fail2ban.enabled?}")
+      Rack::Attack.throttles.keys.each do |throttle|
+        Rails.logger.info("Rack::Attack throttling registered: #{throttle}")
+      end
+    end
 
+    def self.enable_rack_attack!
+      Rails.logger.info("Rack::Attack is now enabled")
+      Rack::Attack.enabled = true
+    end
+
+    def self.disable_rack_attack!
+      Rails.logger.info("Rack::Attack is now disabled")
+      Rack::Attack.enabled = false
+    end
+
+    def self.deactivate_decidim_throttling!
       # Remove the original throttle from decidim-core
-      # see https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
+      # see https://github.com/decidim/decidim/blob/release/0.27-stable/decidim-core/config/initializers/rack_attack.rb#L19
       DecidimApp::RackAttack::Throttling.deactivate_decidim_throttling! do
         Rails.logger.info("Deactivating 'requests by ip' from Decidim Core")
         Rack::Attack.throttles.delete("requests by ip")
       end
+    end
 
+    def self.apply_configuration
       Rack::Attack.throttled_response_retry_after_header = true
 
       Rack::Attack.throttled_responder = lambda do |request|

--- a/spec/lib/decidim_app/rack_attack_spec.rb
+++ b/spec/lib/decidim_app/rack_attack_spec.rb
@@ -62,19 +62,61 @@ describe DecidimApp::RackAttack, type: :request do
     end
   end
 
-  describe "#apply_configuration" do
+  describe "#enable_rack_attack!" do
     before do
-      described_class.apply_configuration
-      Rack::Attack.reset!
+      described_class.enable_rack_attack!
     end
 
+    it "enables Rack::Attack" do
+      expect(Rack::Attack.enabled).to be_truthy
+    end
+  end
+
+  describe "#disable_rack_attack!" do
+    before do
+      described_class.disable_rack_attack!
+    end
+
+    it "enables Rack::Attack" do
+      expect(Rack::Attack.enabled).to be_falsey
+    end
+  end
+
+  describe "#deactivate_decidim_throttling!" do
+    before do
+      described_class.deactivate_decidim_throttling!
+    end
+
+    it "deactivates Decidim throttling" do
+      # Decidim throttling is deactivated by default in rails env test
+      # https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
+      expect(Rack::Attack.throttles.keys).to eq([])
+    end
+  end
+
+  describe "#apply_configuration" do
     describe "Throttling" do
       let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
+      let(:rack_max_requests) { 15 }
 
-      it "successful for 100 requests, then blocks the user" do
-        100.times do
+      before do
+        allow(Rails.application.secrets).to receive(:dig).with(any_args).and_call_original
+        allow(Rails.application.secrets).to receive(:dig).with(:decidim, :rack_attack, :throttle, :max_requests).and_return(rack_max_requests)
+        described_class.apply_configuration
+        Rack::Attack.reset!
+        described_class.enable_rack_attack!
+      end
+
+      it "defines default period and max_requests" do
+        expect(DecidimApp::RackAttack::Throttling.max_requests).to eq(rack_max_requests)
+        expect(DecidimApp::RackAttack::Throttling.period).to eq(60)
+      end
+
+      it "successful for 15 requests, then blocks the user" do
+        rack_max_requests.times do
           get decidim.root_path, params: {}, headers: headers
           expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include("Your connection has been slowed because server received too many requests.")
         end
 
         get decidim.root_path, params: {}, headers: headers
@@ -86,26 +128,16 @@ describe DecidimApp::RackAttack, type: :request do
           expect(response).to have_http_status(:ok)
         end
       end
-
-      it "successful for 99 requests" do
-        99.times do
-          get decidim.root_path, params: {}, headers: headers
-          expect(response).to have_http_status(:ok)
-        end
-
-        get decidim.root_path, params: {}, headers: headers
-        expect(response.body).not_to include("Your connection has been slowed because server received too many requests.")
-        expect(response).not_to have_http_status(:too_many_requests)
-
-        travel_to(1.minute.from_now) do
-          get decidim.root_path, params: {}, headers: headers
-          expect(response).to have_http_status(:ok)
-        end
-      end
     end
 
     describe "Fail2Ban" do
       let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }
+
+      before do
+        described_class.apply_configuration
+        Rack::Attack.reset!
+        described_class.enable_rack_attack!
+      end
 
       %w(/etc/passwd /wp-admin/index.php /wp-login/index.php SELECT CONCAT /.git/config).each do |path|
         it "blocks user for specific request : '#{path}'" do

--- a/spec/lib/decidim_app/rack_attack_spec.rb
+++ b/spec/lib/decidim_app/rack_attack_spec.rb
@@ -90,7 +90,7 @@ describe DecidimApp::RackAttack, type: :request do
     it "deactivates Decidim throttling" do
       # Decidim throttling is deactivated by default in rails env test
       # https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
-      expect(Rack::Attack.throttles.keys).to eq([])
+      expect(Rack::Attack.throttles.keys).to eq(["req/ip"])
     end
   end
 

--- a/spec/lib/decidim_app/rack_attack_spec.rb
+++ b/spec/lib/decidim_app/rack_attack_spec.rb
@@ -90,7 +90,7 @@ describe DecidimApp::RackAttack, type: :request do
     it "deactivates Decidim throttling" do
       # Decidim throttling is deactivated by default in rails env test
       # https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
-      expect(Rack::Attack.throttles.keys).to eq(["req/ip"])
+      expect(Rack::Attack.throttles.keys).to eq([])
     end
   end
 

--- a/spec/lib/decidim_app/rack_attack_spec.rb
+++ b/spec/lib/decidim_app/rack_attack_spec.rb
@@ -82,18 +82,6 @@ describe DecidimApp::RackAttack, type: :request do
     end
   end
 
-  describe "#deactivate_decidim_throttling!" do
-    before do
-      described_class.deactivate_decidim_throttling!
-    end
-
-    it "deactivates Decidim throttling" do
-      # Decidim throttling is deactivated by default in rails env test
-      # https://github.com/decidim/decidim/blob/release/0.26-stable/decidim-core/config/initializers/rack_attack.rb#L19
-      expect(Rack::Attack.throttles.keys).to eq([])
-    end
-  end
-
   describe "#apply_configuration" do
     describe "Throttling" do
       let(:headers) { { "REMOTE_ADDR" => "1.2.3.4", "decidim.current_organization" => organization } }


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Notion card]()

#### Testing
*Describe the best way to test or validate your PR.*

Users may encounter "retry later" because current configuration does not deactivate the throttling pre-defined on Decidim

#### Tasks
- [x] Add specs
- [x] Allow to enable / disable Rack Attack

#### Env vars

`ENABLE_RACK_ATTACK` : Default nil - Set to "1" to enable
Even if env var is not defined, rack attack is enabled for production mode.