### PR TITLE
backport: Dependency Resolver Extends to change gem loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,7 @@ module DevelopmentApp
 
     config.after_initialize do
       require "extends/controllers/decidim/devise/sessions_controller_extends"
+      require "extends/lib/decidim/dependency_resolver_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/lib/extends/lib/decidim/dependency_resolver_extends.rb
+++ b/lib/extends/lib/decidim/dependency_resolver_extends.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Backport from https://github.com/decidim/decidim/pull/12061/files
+# Related to : https://github.com/decidim/decidim/issues/11636
+module DependencyResolverExtends
+  # Finds a gem specification from the locked gems of the instance.
+  #
+  # Note that this does not resolve if the module is needed or not. This may
+  # also return the gem specification even when it is not listed in the
+  # Gemfile, e.g. when the Decidim gems are installed through git.
+  #
+  # @param name [String] The name of the gem to find.
+  # @return [Bundler::LazySpecification, nil] The specification for the gem
+  #   or nil if the gem is not listed in the locked gems.
+  def spec(name)
+    sp = Bundler.definition.locked_gems.specs.find { |s| s.name == name }
+
+    # Fetching the gem through Gem.loaded_specs ensures we are not returning
+    # a lazy specification which does not respond to `#full_gem_path` which
+    # is needed for the resolver.
+    return Gem.loaded_specs[sp.name] if sp
+
+    nil
+  end
+end
+
+Decidim::DependencyResolver::Lookup.class_eval do
+  prepend(DependencyResolverExtends)
+end


### PR DESCRIPTION
#### :tophat: Description
This PR is made to fix the issue of "full_gem_loadpath" as an undefined method

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/Lyon-Fix-version-0-26-8-6a44245b94cd44ab84db5e7dc02924ba?pvs=4)

#### Tasks
- [x] Backport the fix

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
