### PR TITLE
fix: show cta button on process view

### DIFF
--- a/app/views/decidim/shared/_extended_navigation_bar.html.erb
+++ b/app/views/decidim/shared/_extended_navigation_bar.html.erb
@@ -1,0 +1,50 @@
+<div class="row expanded">
+  <div class="process-nav">
+    <div class="row">
+      <button class="process-nav__trigger hide-for-medium" data-toggle="process-nav-content">
+        <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: t("decidim.shared.extended_navigation_bar.unfold"), role: "img" %>
+        <% default_item = active_item || items.first %>
+        <span class="process-nav__link">
+          <%= default_item[:name] %>
+        </span>
+      </button>
+      <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
+        <ul>
+          <% items.each_with_index do |item, index| %>
+            <li class="<%= "is-active" if item[:active] %> <%= "hide-for-medium" if index > max_items %>">
+              <%= link_to item[:url], class: "process-nav__link #{item[:active] ? 'active' : nil}" do %>
+                <%= item[:name] %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+
+        <% if extra_items.any? %>
+          <button class="button tiny process-nav__more show-for-medium" data-toggle="process-nav__hide-content">
+            <%= t("decidim.shared.extended_navigation_bar.more") %> <i></i><i></i><i></i>
+          </button>
+          <div class="dropdown-pane process-nav__hidden-content" id="process-nav__hide-content"
+               data-dropdown
+               data-hover="true"
+               data-hover-pane="true"
+               data-v-offset="-25"
+               data-position="bottom"
+               data-alignment="right">
+            <div class="process-nav__hidden-content__more">
+              <%= t("decidim.shared.extended_navigation_bar.more") %> <i></i><i></i><i></i>
+            </div>
+            <ul>
+              <% extra_items.each do |item| %>
+                <li class="<%= "is-active" if item[:active] %>">
+                  <%= link_to item[:url], class: "process-nav__link #{item[:active] ? 'active' : nil}" do %>
+                    <%= item[:name] %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/decidim/_process_header_steps.html.erb
+++ b/app/views/layouts/decidim/_process_header_steps.html.erb
@@ -1,0 +1,37 @@
+<% if participatory_process.steps.any? %>
+  <div class="columns mediumlarge-4">
+    <div class="process-header__phase">
+      <div class="process-header__progress">
+        <ol>
+          <% past_step = true %>
+          <% participatory_process.steps.each_with_index do |step, index| %>
+            <% if past_step %>
+              <li class="phase-item--past"><span></span></li>
+            <% else %>
+              <li><span></span></li>
+            <% end %>
+            <% past_step = false if step.active? %>
+          <% end %>
+        </ol>
+        <span class="phase-current"><%= t(".step", current: (participatory_process.active_step.position + 1), total: current_participatory_space.steps.count) %></span>
+      </div>
+      <div>
+        <span class="phase-title"><%= translated_attribute participatory_process.active_step.title %></span>
+        <span class="phase-date">
+          <%= participatory_space_helpers.step_dates participatory_process.active_step %>
+        </span>
+      </div>
+      <% cta_text = translated_attribute(participatory_process.active_step.cta_text) %>
+      <% if participatory_process.active_step.cta_path.present? && cta_text.present? %>
+        <%= link_to t(".view_steps"), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_space), class: "clear button secondary tiny" %>
+        <%= link_to(
+              cta_text,
+              step_cta_url(participatory_process),
+              class: "button small button--sc"
+            ) %>
+      <% else %>
+        <%= link_to t(".view_steps"), decidim_participatory_processes.participatory_process_participatory_process_steps_path(current_participatory_space) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -101,6 +101,7 @@ ignore_missing:
  - devise.shared.links.sign_in_with_provider
  - decidim.devise.shared.omniauth_buttons.or
  - decidim.proposals.admin.proposals.bulk-actions.statuses
+ - layouts.decidim.process_header_steps.{step,view_steps}
 
 # Consider these keys used:
 ignore_unused:

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -60,6 +60,7 @@ search:
     - "*.jpeg"
     - "*.odt"
     - "*.docx"
+    - "app/compiled_views/**/*"
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
@@ -102,6 +103,7 @@ ignore_missing:
  - decidim.devise.shared.omniauth_buttons.or
  - decidim.proposals.admin.proposals.bulk-actions.statuses
  - layouts.decidim.process_header_steps.{step,view_steps}
+ - decidim.shared.extended_navigation_bar.{more,unfold}
 
 # Consider these keys used:
 ignore_unused:


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Overrides `app/views/layouts/decidim/_process_header_steps.html.erb` for displaying CTAs buttons on mobile. It removes class `show-for-medium`

Do not expand the menu bar when on mobile


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?
- [Notion card](https://www.notion.so/opensourcepolitics/Lyon-Faire-appara-tre-les-boutons-d-action-en-version-mobile-2a562468d1c9430da77d38fe43961e3b?pvs=4)
