### PR TITLE
fix: custom proposal states emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "decidim", "~> #{DECIDIM_VERSION}.0"
 
 # External Decidim gems
 gem "decidim-cache_cleaner"
-gem "decidim-custom_proposal_states", git: "https://github.com/OpenSourcePolitics/decidim-module-custom_proposal_states", branch: DECIDIM_BRANCH
+gem "decidim-custom_proposal_states", git: "https://github.com/OpenSourcePolitics/decidim-module-custom_proposal_states", branch: "fix/email_encoding"
 gem "decidim-decidim_awesome", "~> 0.9.1"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-slider", git: "https://github.com/OpenSourcePolitics/decidim-module-slider", branch: "rc/0.27"
@@ -32,14 +32,17 @@ gem "bootsnap", "~> 1.4"
 gem "faker", "~> 2.14"
 gem "fog-aws"
 gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git"
+gem "letter_opener_web", "~> 1.3"
 gem "nokogiri", "1.13.4"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "puma", ">= 5.5.1"
 gem "rack-attack", "~> 6.6"
+gem "sidekiq", "~> 6.0"
+gem "sidekiq_alive", "~> 2.2"
+gem "sidekiq-scheduler", "~> 5.0"
 gem "sys-filesystem"
 
 group :development do
-  gem "letter_opener_web", "~> 1.3"
   gem "listen", "~> 3.1"
   gem "rubocop-faker"
   gem "spring", "~> 2.0"
@@ -63,7 +66,4 @@ group :production do
   gem "sentry-rails"
   gem "sentry-ruby"
   gem "sentry-sidekiq"
-  gem "sidekiq", "~> 6.0"
-  gem "sidekiq_alive", "~> 2.2"
-  gem "sidekiq-scheduler", "~> 5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-custom_proposal_states
-  revision: d34f06f13150098e88d54a0bf0b208d6b9bd0b2a
-  branch: release/0.27-stable
+  revision: 4f55fc721eb8fe0c211894d48aece32383da18a8
+  branch: fix/email_encoding
   specs:
     decidim-custom_proposal_states (0.27.5)
       decidim-core (~> 0.27)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,4 +54,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.deface.enabled = ENV.fetch("DEFACE_ENABLED", nil) == "true"
+
+  config.active_job.queue_adapter = :sidekiq
+  config.action_mailer.perform_deliveries = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? || ENV.fetch("ENABLE_LETTER_OPENER", "0") == "1"
 
   mount Decidim::Core::Engine => "/"
   # mount Decidim::Map::Engine => '/map'


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

When custom state contains a special char like : `'`, it is transformed into `&#39;` in email subject for state changed event. In the email body char are well interpreted.

![Screenshot 2024-03-18 at 18 00 42](https://github.com/OpenSourcePolitics/decidim-lyon/assets/26109239/2940f3e4-f504-4596-b71b-33eaee8bb3a0)

- [x] Fix custom state in email subject
- [x] Enable letter opener in production mode

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states/pull/35
- [Notion card](https://www.notion.so/opensourcepolitics/Lyon-Email-char-encoding-in-subject-f30fee2e822b4e26b4d690afb31670e8?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Change event frequency to real_time
* Create proposal
* Change custom state
* See email

