### PR TITLE
fix: Modify default proposal states

### DIFF
--- a/db/migrate/20240115111975_modify_default_proposal_states.decidim_custom_proposal_states.rb
+++ b/db/migrate/20240115111975_modify_default_proposal_states.decidim_custom_proposal_states.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_custom_proposal_states (originally 20231102234909)
+
+class ModifyDefaultProposalStates < ActiveRecord::Migration[6.0]
+  class Proposal < ApplicationRecord
+    belongs_to :proposal_state,
+               class_name: "Decidim::CustomProposalStates::ProposalState",
+               foreign_key: "decidim_proposals_proposal_state_id",
+               inverse_of: :proposals,
+               optional: true
+
+    self.table_name = :decidim_proposals_proposals
+  end
+
+  def up
+    Decidim::Proposals::Proposal.where(state: "")
+                                .or(Decidim::Proposals::Proposal.where(state: nil))
+                                .update_all(state: "not_answered")
+
+    Decidim::Component.where(manifest_name: "proposals").find_each do |component|
+      admin_user = component.organization.admins.first
+      system_custom_proposal_states = Decidim::CustomProposalStates::ProposalState.where(component: component, system: true)
+      next if system_custom_proposal_states.present?
+
+      default_states = Decidim::CustomProposalStates.create_default_states!(component, admin_user).with_indifferent_access
+      Proposal.where(decidim_component_id: component.id).find_each do |proposal|
+        proposal.proposal_state = default_states.dig(proposal.state.to_s, :object)
+        proposal.save!
+      end
+    end
+    change_column_null :decidim_proposals_proposals, :decidim_proposals_proposal_state_id, false
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_15_111974) do
+ActiveRecord::Schema.define(version: 2024_01_15_111975) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1360,7 +1360,7 @@ ActiveRecord::Schema.define(version: 2024_01_15_111974) do
     t.jsonb "body"
     t.integer "comments_count", default: 0, null: false
     t.integer "follows_count", default: 0, null: false
-    t.integer "decidim_proposals_proposal_state_id"
+    t.integer "decidim_proposals_proposal_state_id", null: false
     t.index "md5((body)::text)", name: "decidim_proposals_proposal_body_search"
     t.index "md5((title)::text)", name: "decidim_proposals_proposal_title_search"
     t.index ["answered_at"], name: "index_decidim_proposals_proposals_on_answered_at"


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Create new migration to run data operations in the Custom proposal states migration.

A production error happened because platform was running on v0.27.x Decidim version and required data migration was skipped if decidim version is different than 0.26. 

Proposals were still visible in Backoffice but not in FO anymore.

This PR contains a guard clause if current component have system custom proposal states to prevent duplication
