### PR TITLE
fix: Add budgets importer dropdown in BO

### DIFF
--- a/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -58,7 +58,8 @@
             </td>
             <%= td_resource_scope_for(project.scope) %>
             <td>
-              <%= project.confirmed_orders_count %>
+              <%= project.total_votes %>
+              (<%= project.confirmed_orders_count %>/<%= project.paper_ballots %>)
             </td>
             <td>
               <% if project.selected? %>
@@ -101,5 +102,7 @@
     <strong><%= t ".finished_orders" %>:&nbsp;</strong><span><%= finished_orders.count %></span>
     <span>&nbsp;|&nbsp;</span>
     <strong><%= t ".pending_orders" %>:&nbsp;</strong><span><%= pending_orders.count %></span>
+    <span>&nbsp;|&nbsp;</span>
+    <strong><%= t ".paper_ballots" %>:&nbsp;</strong><span><%= paper_ballots_count %></span>
   </div>
 </div>

--- a/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -1,0 +1,105 @@
+<div class="card with-overflow">
+  <div class="card-divider">
+    <h2 class="card-title flex--sbc">
+      <div>
+        <%= link_to translated_attribute(budget.title), budgets_path %> &gt;
+        <%= t(".title") %>
+      </div>
+      <div class="flex--cc flex-gap--1">
+        <span class="imports dropdown tiny button button--simple" data-toggle="import-dropdown"><%= t "actions.import", scope: "decidim.admin" %></span>
+        <div class="dropdown-pane" id="import-dropdown" data-dropdown data-position=bottom data-alignment=right data-auto-focus="true" data-close-on-click="true">
+          <ul class="vertical menu add-components">
+            <li class="imports--file imports--proposals">
+              <%= link_to t("actions.import", scope: "decidim.budgets", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_proposals_import_path(budget) if allowed_to? :import_proposals, :project %>
+            </li>
+            <li class="imports--file imports--projects">
+              <%= link_to t("actions.import", scope: "decidim.budgets_importer", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_projects_import_path(budget) if allowed_to? :import_proposals, :project %>
+            </li>
+          </ul>
+        </div>
+
+
+        <% if allowed_to? :export, :budget %>
+          <%= export_dropdown(current_component, budget.id) %>
+        <% end %>
+        <%= link_to t("actions.new", scope: "decidim.budgets", name: t("models.project.name", scope: "decidim.budgets.admin")), new_budget_project_path, class: "button tiny button--title new" if allowed_to? :create, :project %>
+      </div>
+    </h2>
+  </div>
+
+  <%= admin_filter_selector(:projects) %>
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="table-list">
+        <thead>
+        <tr>
+          <th><%= sort_link(query, :id, t("models.project.fields.id", scope: "decidim.budgets"), default_order: :desc) %>
+          <th><%= sort_link(query, :title, t("models.project.fields.title", scope: "decidim.budgets")) %></th>
+          <th><%= sort_link(query, :category_name, t("models.project.fields.category", scope: "decidim.budgets") ) %></th>
+          <%= th_scope_sort_link %>
+          <th><%= sort_link(query, :confirmed_orders_count, t("index.confirmed_orders_count")) %></th>
+          <th><%= sort_link(query, :selected, t(".selected")) %></th>
+          <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
+        </tr>
+        </thead>
+        <tbody>
+        <% projects.each do |project| %>
+          <tr data-id="<%= project.id %>">
+            <td>
+              <%= project.id %><br>
+            </td>
+            <td>
+              <%= translated_attribute(project.title) %><br>
+            </td>
+            <td>
+              <% if project.category %>
+                <%= translated_attribute project.category.name %>
+              <% end %>
+            </td>
+            <%= td_resource_scope_for(project.scope) %>
+            <td>
+              <%= project.confirmed_orders_count %>
+            </td>
+            <td>
+              <% if project.selected? %>
+                <%= content_tag :strong, t(".selected"), class: "text-success" %>
+              <% else %>
+                <%= content_tag :span, "×", class: "text-muted" %>
+              <% end %>
+            </td>
+            <td class="table-list__actions">
+              <%= icon_link_to "eye", resource_locator([budget, project]).path, t("actions.preview", scope: "decidim.budgets"), target: :blank, class: "action-icon--preview" %>
+
+              <% if allowed_to? :update, :project, project: project %>
+                <%= icon_link_to "pencil", resource_locator([budget, project]).edit, t("actions.edit", scope: "decidim.budgets"), class: "action-icon--edit" %>
+              <% end %>
+
+              <% if allowed_to? :update, :project, project: project %>
+                <%= icon_link_to "folder", project_attachment_collections_path(project), t("actions.attachment_collections", scope: "decidim.budgets"), class: "action-icon--attachment_collections" %>
+              <% end %>
+
+              <% if allowed_to? :update, :project, project: project %>
+                <%= icon_link_to "paperclip", project_attachments_path(project), t("actions.attachments", scope: "decidim.budgets"), class: "action-icon--attachments" %>
+              <% end %>
+
+              <%= resource_permissions_link(project) %>
+
+              <% if allowed_to? :destroy, :project, project: project %>
+                <%= icon_link_to "circle-x", resource_locator([budget, project]).show, t("actions.destroy", scope: "decidim.budgets"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.budgets") } %>
+              <% else %>
+                <%= icon "circle-x", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.destroy", scope: "decidim.budgets") %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+      <%= paginate projects, theme: "decidim" %>
+    </div>
+  </div>
+  <div class="card-divider">
+    <strong><%= t ".finished_orders" %>:&nbsp;</strong><span><%= finished_orders.count %></span>
+    <span>&nbsp;|&nbsp;</span>
+    <strong><%= t ".pending_orders" %>:&nbsp;</strong><span><%= pending_orders.count %></span>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -104,6 +104,13 @@ ignore_missing:
  - decidim.proposals.admin.proposals.bulk-actions.statuses
  - layouts.decidim.process_header_steps.{step,view_steps}
  - decidim.shared.extended_navigation_bar.{more,unfold}
+ - decidim.budgets.admin.projects.index.*
+ - decidim.budgets.admin.models.project.name
+ - decidim.budgets.actions.*
+ - decidim.budgets.models.project.fields.*
+ - decidim.admin.actions.import
+ - decidim.budgets_importer.actions.import
+ - index.confirmed_orders_count
 
 # Consider these keys used:
 ignore_unused:


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Add budgets importer dropdown option in the budgets projects index page

#### :pushpin: Related Issues
*Link your PR to an issue*

- [Notion card](https://www.notion.so/opensourcepolitics/Lyon-Dev-Probl-me-avec-l-ajout-du-Budget-importer-396cc7ae97cd40c9899dfe52698002f7?pvs=4)

