### PR TITLE
fix:add french translation key for paper_ballot module

### DIFF
--- a/config/locales/decidim-budgets_paper_ballots/fr.yml
+++ b/config/locales/decidim-budgets_paper_ballots/fr.yml
@@ -1,0 +1,42 @@
+fr:
+  activemodel:
+    attributes:
+      paper_ballot_result:
+        decidim_project_id: Projet
+        votes: Votes
+  decidim:
+    budgets:
+      actions:
+        import_results: Importer les bulletins papier
+      admin:
+        budgets:
+          index:
+            paper_ballots: Bulletins papier
+        imports:
+          help:
+            paper_ballot_results: "Le document d'importation doit contenir les colonnes suivantes : 'id' (avec l'id du projet) et 'paper_ballots_to_import' (avec le nombre de nouveaux votes pour le projet à importer). Vous pouvez simplement réutiliser une exportation de tous les projets et ajouter une colonne nommée 'paper_ballots_to_import'."
+          label:
+            paper_ballot_results: Importer les bulletins papier
+          resources:
+            paper_ballot_results:
+              one: résultat de bulletin papier
+              other: résultats de bulletins papier
+          title:
+            paper_ballot_results: Importer les résultats des bulletins papier
+        models:
+          paper_ballot_result: Résultat de bulletin papier
+        projects:
+          index:
+            paper_ballots: Bulletins papier
+        paper_ballots_imports:
+          new:
+            create: Importer les bulletins papier
+            title: Importer les bulletins papier
+      admin_log:
+        paper_ballot_result:
+          create: "%{user_name} a importé les résultats des bulletins papier dans l'espace %{space_name}"
+      models:
+        paper_ballot_result:
+          fields:
+            id: ID
+            votes: Votes


### PR DESCRIPTION
#### :tophat: Description
The french translation keys are missing with the paper_ballot module

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/Lyon-Dev-Cl-de-trad-manquant-avec-le-module-paper-ballot-f63d3d548ef1421089e73873364c020f?pvs=4)

#### Testing
As admin, Go to a process budget 

<img width="1498" alt="Capture d’écran 2024-06-19 à 17 11 26" src="https://github.com/OpenSourcePolitics/decidim-lyon/assets/143180473/f2b1897c-2b97-4290-8369-6e1b5897ce19">


#### Tasks
- [x] Add Fr Key trad
- [ ]

