### PR TITLE
fix:budget_importer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-budgets_importer.git
-  revision: eec557bf67a3cd0e00a1c6bdcc8aa56e4908b635
+  revision: 62d9a328d94e39ad005431d1dca7f1d0455e937c
   branch: main
   specs:
     decidim-budgets_importer (2.0.0)
@@ -175,8 +175,8 @@ GEM
       zeitwerk (~> 2.3)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.941.0)
@@ -491,7 +491,7 @@ GEM
       nokogiri (>= 1.13.2, < 1.17.0)
       rubyzip (~> 2.3.0)
     docile (1.4.0)
-    doorkeeper (5.7.0)
+    doorkeeper (5.7.1)
       railties (>= 5)
     doorkeeper-i18n (4.0.1)
     dotenv (3.1.2)
@@ -509,7 +509,7 @@ GEM
       smart_properties
     erbse (0.1.4)
       temple
-    erubi (1.12.0)
+    erubi (1.13.0)
     escape_utils (1.3.0)
     et-orbi (1.2.11)
       tzinfo
@@ -524,7 +524,7 @@ GEM
       railties (>= 3.0.0)
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.9.1)
+    faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
@@ -603,7 +603,7 @@ GEM
       rails (>= 3.2.0)
     jmespath (1.6.2)
     json (2.7.2)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -657,9 +657,9 @@ GEM
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0604)
-    mini_magick (4.12.0)
+    mini_magick (4.13.1)
     mini_mime (1.1.5)
-    minitest (5.23.1)
+    minitest (5.24.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -671,7 +671,7 @@ GEM
     mustache (1.1.1)
     net-http (0.4.1)
       uri
-    net-imap (0.4.12)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -744,7 +744,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
-    public_suffix (5.0.5)
+    public_suffix (6.0.0)
     puma (5.6.8)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -1006,7 +1006,7 @@ GEM
     wkhtmltopdf-binary (0.12.6.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   arm64-darwin-22


### PR DESCRIPTION
🎩 Description
Fix the unexpected appearance of "budgetimporter" in the list components dropdown 

📌 Related Issues
[Notion card](/opensourcepolitics/Budget-Importer-Le-budget-importer-est-pr-sent-dans-la-liste-des-fonctionnalit-s-des-Process-et-As-6e50351e7a904b4e82945a220b9f5368?pvs=4)

Testing

1. As admin go to dashboard
2. Go to a process 
3. Go to components
4. Click on "add component"
5. You can see that budget_importer isn't displayed anymore 🎉
9. 
10. Option: If you want to confirm that budget importer still works, you can follow this steps => https://github.com/OpenSourcePolitics/decidim-lyon/pull/84


📷 Screenshots
<img width="1441" alt="Capture d’écran 2024-06-25 à 17 41 02" src="https://github.com/OpenSourcePolitics/decidim-module-budgets_importer/assets/143180473/0cb9a357-f54c-4f69-acbf-906dbaefb02a">
