### PR TITLE
fix: Downgrade wicked pdf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "sidekiq", "~> 6.0"
 gem "sidekiq_alive", "~> 2.2"
 gem "sidekiq-scheduler", "~> 5.0"
 gem "sys-filesystem"
+gem "wicked_pdf", "2.6.3"
 
 group :development do
   gem "listen", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -999,7 +999,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.8.0)
+    wicked_pdf (2.6.3)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
@@ -1063,6 +1063,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   sys-filesystem
   web-console (= 4.0.4)
+  wicked_pdf (= 2.6.3)
 
 RUBY VERSION
    ruby 3.0.6p216

--- a/spec/wicked_pdf_spec.rb
+++ b/spec/wicked_pdf_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "WickedPdf" do
+  it "has version 2.6.3" do
+    expect(WickedPdf::VERSION).to eq("2.6.3")
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*
Downgrading wicked pdf to fix the issue of exporting surveys

#### :pushpin: Related Issues
*Link your PR to an issue*
- [[LYON] Downgrade Wicked_pdf signature](https://www.notion.so/opensourcepolitics/LYON-Downgrade-Wicked_pdf-signature-47f773fb68f44b58a44b3ec6d5dae87e?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as admin
* Access Backoffice
* Go to a processes settings
* Enable a survey
* Fill and submit the survey
* Go back to the back office
* Exports the answers
* Check if it appears on the letter opener
* If it doesn't go to the sidekiq interface `/sidekiq`
* Login as system 
* Make sure it is enqueued and not failed

#### Tasks
- [x] Add specs
- [x] Downgrade wicked_pdf

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
