### PR TITLE
Bump: simple_proposal update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GIT
 
 GIT
   remote: https://github.com/opensourcepolitics/decidim-module-simple_proposal.git
-  revision: 2c3c9a1abd5612b93a5fbce896a33b1a0f34931e
+  revision: 63f67e77aa0218eda01125e1cee3397c2d2b0d87
   branch: release/0.27-stable
   specs:
     decidim-simple_proposal (0.27.0)
@@ -536,6 +536,8 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
     file_validators (3.0.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
@@ -689,6 +691,8 @@ GEM
       net-protocol
     nio4r (2.7.3)
     nokogiri (1.13.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
@@ -1019,6 +1023,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -1076,4 +1081,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.4.22
+   2.5.10


### PR DESCRIPTION
#### :tophat: Description
Bump of updated decidim-module-simple_proposal

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=90e91311d0d34edda7cb98c2e8a754e9&pm=c)

#### Testing
As an admin, go to a process
Go to the configuration of proposals component
Select in the "Default proposal sorting" , the "Default" value and update
Go to the process public page, go to proposals and see that the Order by filter is set to "Random" (which correspond to the default value, cf screenshot), and not "Recent"
As an admin, change the value of the "Default proposal sorting" and update
See in the public page that the filter is now set to the new value

