### PR TITLE
Fix export dropdown in admin proposals index

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,7 @@ ignore_unused:
   - activemodel.errors.models.proposal.attributes.attachment.needs_to_be_reattached
   - budgets.projects_helper.current_rule_description.*
   - budgets.projects_helper.current_rule_explanation.*
+  - decidim.admin.exports.export_as
   - decidim.components.budgets.settings.global.geocoding_enabled
   - decidim.budgets.actions.*
   - decidim.budgets.admin.budgets.index.*
@@ -146,6 +147,8 @@ ignore_unused:
   - decidim.meetings.meetings.create.*
   - decidim.meetings.meetings.update.*
   - decidim.omniauth.france_connect.*
+  - decidim.proposals.admin.exports.awesome_private_proposals
+  - decidim.proposals.admin.exports.proposal_comments
   - decidim.proposals.collaborative_drafts.collaborative_draft.publish.*
   - decidim.proposals.collaborative_drafts.collaborative_draft.withdraw.*
   - decidim.proposals.collaborative_drafts.create.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
     accessibility:
       skip_button: Skip button
     admin:
+      exports:
+        export_as: "%{name} as %{export_format}"
       participatory_space_private_users:
         create:
           error: Error
@@ -193,6 +195,10 @@ en:
       show:
         local_area: Local area
     proposals:
+      admin:
+        exports:
+          awesome_private_proposals: Proposals with private fields
+          proposal_comments: Comments
       collaborative_drafts:
         collaborative_draft:
           publish:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,6 +40,8 @@ fr:
     accessibility:
       skip_button: Passer au contenu principal
     admin:
+      exports:
+        export_as: "%{name} au format %{export_format}"
       participatory_space_private_users:
         create:
           error: Erreur
@@ -198,6 +200,9 @@ fr:
         local_area: Espace d'organisation
     proposals:
       admin:
+        exports:
+          awesome_private_proposals: Propositions avec champs privés
+          proposal_comments: Commentaires
         proposals:
           bulk-actions:
             statuses: Nouveaux status


### PR DESCRIPTION
#### :tophat: Description
Addition of missing translations keys for the dropdown export button in admin proposals index.

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=fff5d39996a78063a0a8c6a37ff033d8&pm=c)

#### Testing

1. As an admin, go to a process
2. Got to proposals
3. Click on "Export" button and see that you have the needed translations fo the different types of exports.
4. Change the language for french and see that you have the needed translations

### :camera: Screenshots
<img width="750" alt="Capture d’écran 2024-08-29 à 10 38 57" src="https://github.com/user-attachments/assets/e7466c21-8ad2-4964-9a39-4f6cff27e4e8">

