### PR TITLE
fix(sidekiq): duplicate sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,7 +13,6 @@
   - block_user
   - active_storage_analysis
   - active_storage_purge
-  - user_report
   - translations
 
 :scheduler:


### PR DESCRIPTION
The queue `user_report` is duplicated

![image](https://github.com/user-attachments/assets/10b4e9f0-84e4-4ed9-a56c-d52756616fba)
