### PR TITLE
fix: Add Spam bot rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decid
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-simple_proposal", git: "https://github.com/opensourcepolitics/decidim-module-simple_proposal.git", branch: DECIDIM_BRANCH
 gem "decidim-slider", git: "https://github.com/OpenSourcePolitics/decidim-module-slider", branch: "rc/0.27"
-gem "decidim-spam_detection", "4.0.0"
+gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", tag: "4.1.0"
 gem "decidim-term_customizer", git: "https://github.com/opensourcepolitics/decidim-module-term_customizer.git", branch: "fix/multi-threading-compliant"
 
 # Omniauth gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,14 @@ GIT
       decidim-core (~> 0.27.0)
 
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
+  revision: 52623c57f571716730532eab8757560818f7f1df
+  tag: 4.1.0
+  specs:
+    decidim-spam_detection (4.1.0)
+      decidim-core (~> 0.27.0)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/omniauth-publik
   revision: ab703a565c402b773ce0025593554b329f603e5c
   specs:
@@ -453,8 +461,6 @@ GEM
       decidim-comments (= 0.27.5)
       decidim-core (= 0.27.5)
       decidim-proposals (= 0.27.5)
-    decidim-spam_detection (4.0.0)
-      decidim-core (~> 0.27.0)
     decidim-surveys (0.27.5)
       decidim-core (= 0.27.5)
       decidim-forms (= 0.27.5)
@@ -536,8 +542,6 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.0)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
     file_validators (3.0.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
@@ -1047,7 +1051,7 @@ DEPENDENCIES
   decidim-homepage_interactive_map!
   decidim-simple_proposal!
   decidim-slider!
-  decidim-spam_detection (= 4.0.0)
+  decidim-spam_detection!
   decidim-term_customizer!
   dotenv-rails
   faker (~> 2.14)
@@ -1081,4 +1085,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.10
+   2.4.6

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -43,3 +43,8 @@
       class: NotificationsDigestMailJob
       queue: mailers
       args: :weekly
+    SpamBotBlockUsers:
+      cron: '0 <%= Random.rand(0..59) %> <%= Random.rand(6..8) %> * * *' # Run randomly between 06:00 and 08:59
+      class: Decidim::SpamDetection::BlockUsersJob
+      queue: default
+      enabled: false


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Bump spam-detection-bot module to `0.4.1`

