### PR TITLE
fix: Disable author tooltip

### DIFF
--- a/app/presenters/concerns/decidim/user_presenter_concern.rb
+++ b/app/presenters/concerns/decidim/user_presenter_concern.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module UserPresenterConcern
+    extend ActiveSupport::Concern
+
+    included do
+      def has_tooltip?
+        false
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module DevelopmentApp
 
     config.to_prepare do
       ActiveStorage::Blob.include ActiveStorage::Downloadable
+      Decidim::UserPresenter.include Decidim::UserPresenterConcern
     end
 
     config.after_initialize do

--- a/spec/presenters/decidim/user_presenter_spec.rb
+++ b/spec/presenters/decidim/user_presenter_spec.rb
@@ -92,7 +92,7 @@ module Decidim
       it do
         expect(subject).to \
           have_link(user.nickname, href: "http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}") &
-            have_selector(".user-mention")
+          have_selector(".user-mention")
       end
     end
 
@@ -129,6 +129,12 @@ module Decidim
             expect(subject).to be_nil
           end
         end
+      end
+
+      describe "#has_tooltip?" do
+        subject { described_class.new(user).has_tooltip? }
+
+        it { is_expected.to be_falsey }
       end
     end
   end

--- a/spec/presenters/decidim/user_presenter_spec.rb
+++ b/spec/presenters/decidim/user_presenter_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe UserPresenter, type: :helper do
+    let(:user) { build(:user) }
+
+    describe "#nickname" do
+      subject { described_class.new(user).nickname }
+
+      context "when not blocked" do
+        it { is_expected.to eq("@#{user.nickname}") }
+      end
+
+      context "when blocked" do
+        before do
+          user.blocked = true
+        end
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "#can_be_contacted?" do
+      subject { described_class.new(user).can_be_contacted? }
+
+      context "when user is not blocked" do
+        it "can be contacted" do
+          expect(subject).to be(true)
+        end
+      end
+
+      context "when user is blocked" do
+        it "cannot be contacted" do
+          user.blocked = true
+
+          expect(subject).to be_nil
+        end
+      end
+    end
+
+    describe "#profile_url" do
+      subject { described_class.new(user).profile_url }
+
+      it { is_expected.to eq("http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}") }
+    end
+
+    describe "#default_avatar_url" do
+      subject { described_class.new(user).default_avatar_url }
+
+      it { is_expected.to eq("//#{user.organization.host}:#{Capybara.server_port}#{ActionController::Base.helpers.asset_pack_path("media/images/default-avatar.svg")}") }
+    end
+
+    context "when user is not officialized" do
+      describe "#badge" do
+        subject { described_class.new(user).badge }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    context "when user is officialized" do
+      let(:user) { build(:user, :officialized) }
+
+      describe "#badge" do
+        subject { described_class.new(user).badge }
+
+        it { is_expected.to eq("verified-badge") }
+      end
+    end
+
+    describe "#profile_path" do
+      subject { described_class.new(user).profile_path }
+
+      it { is_expected.to eq("/profiles/#{user.nickname}") }
+    end
+
+    context "when user is deleted" do
+      let(:user) { build(:user, :deleted) }
+
+      describe "#profile_path" do
+        subject { described_class.new(user).profile_path }
+
+        it { is_expected.to eq("") }
+      end
+    end
+
+    describe "#display_mention" do
+      subject { described_class.new(user).display_mention }
+
+      it do
+        expect(subject).to \
+          have_link(user.nickname, href: "http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}") &
+            have_selector(".user-mention")
+      end
+    end
+
+    context "when user is a group" do
+      let(:user) { build(:user_group) }
+
+      describe "#profile_path" do
+        subject { described_class.new(user).profile_path }
+
+        it { is_expected.to eq("/profiles/#{user.nickname}") }
+      end
+
+      describe "#profile_url" do
+        subject { described_class.new(user).profile_url }
+
+        let(:host) { user.organization.host }
+
+        it { is_expected.to eq("http://#{host}:#{Capybara.server_port}/profiles/#{user.nickname}") }
+      end
+
+      describe "#can_be_contacted?" do
+        subject { described_class.new(user).can_be_contacted? }
+
+        context "when group is not blocked" do
+          it "can be contacted" do
+            expect(subject).to be(true)
+          end
+        end
+
+        context "when group is blocked" do
+          it "cannot be contacted" do
+            user.blocked = true
+
+            expect(subject).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR extends the user presenter to disable the author tooltip in views


Tooltip example: 

![Screenshot 2024-11-05 at 16 49 31](https://github.com/user-attachments/assets/33b4513b-ee84-453b-858f-7c2e2214591f)
