### PR TITLE
fix: Remove proposals map from index

### DIFF
--- a/app/views/decidim/proposals/proposals/index.html.erb
+++ b/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,0 +1,31 @@
+<%= render partial: "decidim/shared/component_announcement" %>
+
+<%= render partial: "voting_rules" %>
+<div class="row columns">
+  <div class="title-action">
+    <h2 id="proposals-count" class="title-action__title section-heading">
+      <%= render partial: "count" %>
+    </h2>
+    <% if current_settings.creation_enabled && current_component.participatory_space.can_participate?(current_user) %>
+      <%= action_authorized_link_to :create, new_proposal_path, class: "title-action__action button small", data: { "redirect_url" => new_proposal_path } do %>
+        <%= t(".new_proposal") %>
+        <%= icon "plus", role: "img", "aria-hidden": true %>
+      <% end %>
+    <% end %>
+
+    <% if component_settings.collaborative_drafts_enabled? %>
+      <%= link_to t(".collaborative_drafts_list"), collaborative_drafts_path, class: "title-action__action button small hollow ml-s" %>
+    <% end %>
+  </div>
+</div>
+<div class="row">
+  <div class="columns mediumlarge-4 large-3">
+    <%= render partial: "filters_small_view" %>
+    <div class="card card--secondary show-for-mediumlarge">
+      <%= render partial: "filters" %>
+    </div>
+  </div>
+  <div id="proposals" class="columns mediumlarge-8 large-9" aria-live="polite">
+    <%= render partial: "proposals" %>
+  </div>
+</div>

--- a/app/views/decidim/proposals/proposals/index.js.erb
+++ b/app/views/decidim/proposals/proposals/index.js.erb
@@ -1,0 +1,10 @@
+var $proposals = $('#proposals');
+var $proposalsCount = $('#proposals-count');
+var $orderFilterInput = $('.order_filter');
+
+$proposals.html('<%= j(render partial: "proposals").strip.html_safe %>');
+$proposalsCount.html('<%= j(render partial: "count").strip.html_safe %>');
+$orderFilterInput.val('<%= order %>');
+
+var $dropdownMenu = $('.dropdown.menu', $proposals);
+$dropdownMenu.foundation();

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,4 +57,5 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.perform_deliveries = true
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "debug").to_sym
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -111,7 +111,7 @@ ignore_missing:
  - decidim.admin.actions.import
  - decidim.budgets_importer.actions.import
  - index.confirmed_orders_count
-
+ - decidim.proposals.proposals.index.{new_proposal,collaborative_drafts_list}
 # Consider these keys used:
 ignore_unused:
   - faker.*


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

- This PR removes the proposal map from the proposal component index page. 
- Allow to change Rails log level in development mode

### :camera: Notes

🚨 This PR is temporary to enhance page performances. At the moment, the map is hidden using CSS directly from header snippet.
