### PR TITLE
fix: Remove vote weight feat from awesome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "decidim-budgets_paper_ballots", git: "https://github.com/digidemlab/decidim
 
 gem "decidim-cache_cleaner"
 gem "decidim-custom_proposal_states", git: "https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states", branch: DECIDIM_BRANCH
-gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome", branch: DECIDIM_BRANCH
+gem "decidim-decidim_awesome", git: "https://github.com/Quentinchampenois/decidim-module-decidim_awesome", branch: "rc/0.27-without-vote-weighted"
 gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: DECIDIM_BRANCH
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,9 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git
-  revision: 1c91e024ae4467c097b39673e5d78b06afd206d1
+  revision: 91756c7324172f39375519ab957704359f21c2b6
   specs:
-    decidim-friendly_signup (0.4.5)
+    decidim-friendly_signup (0.4.6)
       decidim-core (~> 0.27)
 
 GIT
@@ -68,25 +68,25 @@ GIT
       omniauth-oauth2 (>= 1.7.2, < 2.0)
 
 GIT
-  remote: https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states
-  revision: 66bc4d1a9f00eb66356e583365597e737e1d6917
-  branch: release/0.27-stable
-  specs:
-    decidim-custom_proposal_states (0.27.5)
-      decidim-core (~> 0.27)
-      decidim-proposals (~> 0.27)
-      deface (>= 1.9)
-
-GIT
-  remote: https://github.com/decidim-ice/decidim-module-decidim_awesome
-  revision: 51bc593da8fb72d14c2e5b5df55dbb686be1fbbe
-  branch: release/0.27-stable
+  remote: https://github.com/Quentinchampenois/decidim-module-decidim_awesome
+  revision: 03a5b90f038d0662d61dc25ef3acf7692eb3dd87
+  branch: rc/0.27-without-vote-weighted
   specs:
     decidim-decidim_awesome (0.10.3)
       decidim-admin (>= 0.26.0, < 0.28)
       decidim-core (>= 0.26.0, < 0.28)
       deface (>= 1.5)
       sassc (~> 2.3)
+
+GIT
+  remote: https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states
+  revision: 848eb550d44d9bebc9e72c458c4e3aab79203d9e
+  branch: release/0.27-stable
+  specs:
+    decidim-custom_proposal_states (0.27.5)
+      decidim-core (~> 0.27)
+      decidim-proposals (~> 0.27)
+      deface (>= 1.9)
 
 GIT
   remote: https://github.com/digidemlab/decidim-module-budgets_paper_ballots

--- a/spec/models/proposal_extra_field_spec.rb
+++ b/spec/models/proposal_extra_field_spec.rb
@@ -183,47 +183,6 @@ module Decidim::DecidimAwesome
       end
     end
 
-    describe "all_vote_weights" do
-      let!(:extra_fields) { create(:awesome_proposal_extra_fields, proposal: proposal) }
-      let!(:another_extra_fields) { create(:awesome_proposal_extra_fields, proposal: another_proposal) }
-      let!(:unrelated_another_extra_fields) { create(:awesome_proposal_extra_fields, :with_votes, proposal: create(:extended_proposal)) }
-      let(:another_proposal) { create(:proposal, component: proposal.component) }
-      let!(:votes) do
-        vote = create(:proposal_vote, proposal: proposal, author: create(:user, organization: proposal.organization))
-        create(:awesome_vote_weight, vote: vote, weight: 1)
-      end
-      let!(:other_votes) do
-        vote = create(:proposal_vote, proposal: another_proposal, author: create(:user, organization: proposal.organization))
-        create(:awesome_vote_weight, vote: vote, weight: 2)
-      end
-
-      it "returns all vote weights for a component" do
-        expect(proposal.reload.all_vote_weights).to contain_exactly(1, 2)
-        expect(another_proposal.reload.all_vote_weights).to contain_exactly(1, 2)
-        expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })
-        expect(another_proposal.vote_weights).to eq({ "1" => 0, "2" => 1 })
-      end
-
-      context "when wrong cache exists" do
-        before do
-          # rubocop:disable Rails/SkipsModelValidations:
-          # we don't want to trigger the active record hooks
-          extra_fields.update_columns(vote_weight_totals: { "3" => 1, "4" => 1 })
-          # rubocop:enable Rails/SkipsModelValidations:
-        end
-
-        it "returns all vote weights for a component" do
-          expect(proposal.reload.extra_fields.vote_weight_totals).to eq({ "3" => 1, "4" => 1 })
-          expect(proposal.vote_weights).to eq({ "1" => 0, "2" => 0 })
-          proposal.update_vote_weights!
-          expect(proposal.vote_weights).to eq({ "1" => 1, "2" => 0 })
-          expect(another_proposal.reload.vote_weights).to eq({ "1" => 0, "2" => 1 })
-          expect(proposal.extra_fields.vote_weight_totals).to eq({ "1" => 1 })
-          expect(another_proposal.extra_fields.vote_weight_totals).to eq({ "2" => 1 })
-        end
-      end
-    end
-
     describe "private_body" do
       it "returns nil if no private_body" do
         expect(extra_fields.private_body).to be_nil

--- a/spec/models/proposal_extra_field_spec.rb
+++ b/spec/models/proposal_extra_field_spec.rb
@@ -28,66 +28,6 @@ module Decidim::DecidimAwesome
       expect(extra_fields.proposal.reload.extra_fields).to eq(extra_fields)
     end
 
-    describe "weight_count" do
-      let!(:extra_fields) { create(:awesome_proposal_extra_fields, proposal: proposal) }
-      let!(:vote_weights) do
-        proposal
-        [
-          create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 1),
-          create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 2),
-          create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 3)
-        ]
-      end
-
-      it "returns the weight count for a weight" do
-        expect(proposal.reload.weight_count(1)).to eq(1)
-        expect(proposal.weight_count(2)).to eq(1)
-        expect(proposal.weight_count(3)).to eq(1)
-      end
-
-      context "when a vote is added" do
-        before do
-          create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 5)
-          create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 3)
-        end
-
-        it "returns the weight count for a weight" do
-          expect(proposal.reload.weight_count(1)).to eq(1)
-          expect(proposal.weight_count(2)).to eq(1)
-          expect(proposal.weight_count(3)).to eq(2)
-          expect(proposal.weight_count(4)).to eq(0)
-          expect(proposal.weight_count(5)).to eq(1)
-        end
-      end
-
-      context "when extra_fields does not exist" do
-        let(:extra_fields) { nil }
-        let(:vote_weights) { nil }
-
-        it "returns 0" do
-          expect(proposal.reload.weight_count(1)).to eq(0)
-          expect(proposal.weight_count(2)).to eq(0)
-          expect(proposal.weight_count(3)).to eq(0)
-          expect(proposal.weight_count(100)).to eq(0)
-        end
-
-        context "when a vote is added" do
-          before do
-            create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 5)
-            create(:awesome_vote_weight, vote: create(:proposal_vote, proposal: proposal), weight: 3)
-          end
-
-          it "returns the weight count for a weight" do
-            expect(proposal.reload.weight_count(1)).to eq(0)
-            expect(proposal.weight_count(2)).to eq(0)
-            expect(proposal.weight_count(3)).to eq(1)
-            expect(proposal.weight_count(4)).to eq(0)
-            expect(proposal.weight_count(5)).to eq(1)
-          end
-        end
-      end
-    end
-
     context "when proposal is destroyed" do
       let!(:extra_fields) { create(:awesome_proposal_extra_fields, proposal: proposal) }
 


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Disable feature Proposal Vote Weight from Decidim Awesome to reduce queries about extra private fields
see:

https://github.com/decidim-ice/decidim-module-decidim_awesome/blob/d3ad84446fa0970a95b1c76e5d2f7e44de4d64a3/app/cells/concerns/decidim/decidim_awesome/proposal_m_cell_override.rb#L12
https://github.com/decidim-ice/decidim-module-decidim_awesome/blob/d3ad84446fa0970a95b1c76e5d2f7e44de4d64a3/lib/decidim/decidim_awesome/engine.rb#L80

### :camera: Note
🚨 There is no more proposal vote weight feature from Awesome
