### PR TITLE
fix: Adjust probability score for spam detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decid
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-simple_proposal", git: "https://github.com/opensourcepolitics/decidim-module-simple_proposal.git", branch: DECIDIM_BRANCH
 gem "decidim-slider", git: "https://github.com/OpenSourcePolitics/decidim-module-slider", branch: "rc/0.27"
-gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", tag: "4.1.1"
+gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git", tag: "4.1.2"
 gem "decidim-term_customizer", git: "https://github.com/opensourcepolitics/decidim-module-term_customizer.git", branch: "fix/multi-threading-compliant"
 
 # Omniauth gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,10 +53,10 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
-  revision: fb2ee4624b728ce6f73603bfb84eda1d9b4e04d4
-  tag: 4.1.1
+  revision: 5e4f92f19b903228b8349fb002d735e900d63ed4
+  tag: 4.1.2
   specs:
-    decidim-spam_detection (4.1.1)
+    decidim-spam_detection (4.1.2)
       decidim-core (~> 0.27.0)
 
 GIT


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

- Allow to reduce the spam probability score using env var `SPAM_DETECTION_BLOCKING_LEVEL`

Used in `bundle exec rake decidim:spam_detection:block_users`

## Environment

* `SPAM_DETECTION_BLOCKING_LEVEL` (default: 0.99) OPTIONAL