### PR TITLE
fix: Separator in attachment urls

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,7 +14,6 @@ scaleway:
   region: fr-par
   bucket: <%= Rails.application.secrets.dig(:scaleway, :bucket_name) %>
   force_path_style: true
-  public: true
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:

--- a/lib/extends/serializers/proposals/proposals_serializer_extends.rb
+++ b/lib/extends/serializers/proposals/proposals_serializer_extends.rb
@@ -50,7 +50,7 @@ module ProposalSerializerExtends
   def attachment_urls
     proposal.attachments.map do |attc|
       Rails.application.routes.url_helpers.rails_blob_url(attc.file.blob, host: proposal.participatory_space.organization.host)
-    end.join(",")
+    end.join("\n")
   end
 end
 


### PR DESCRIPTION
#### Description

- Fix Active Storage
- Update Separator