### PR TITLE
feat: Addition of Half Signup

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -22,3 +22,14 @@ DECIDIM_SESSION_TIMEOUT=
 # RAILS_LOG_LEVEL=warn
 
 # DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED=disabled # or enabled
+
+# SMS_GATEWAY_SERVICE="Decidim::SmsGatewayService"
+# SMS_GATEWAY_URL="https://sms.gateway.service/api"
+# SMS_GATEWAY_BULK_URL="https://sms.gateway.service/api/bulk"
+# SMS_GATEWAY_USERNAME=
+# SMS_GATEWAY_PASSWORD=
+## Set to replace the organization name
+# SMS_GATEWAY_PLATFORM="hashimoto.local"
+
+# Redirect to the TOS page after signup (default: true)
+# DECIDIM_HALF_SIGNUP_SHOW_TOS_PAGE_AFTER_SIGNUP=true

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,9 @@ gem "decidim-budgets_paper_ballots", git: "https://github.com/digidemlab/decidim
 gem "decidim-cache_cleaner"
 gem "decidim-custom_proposal_states", git: "https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states", branch: DECIDIM_BRANCH
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome", branch: DECIDIM_BRANCH
-gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: DECIDIM_BRANCH
+gem "decidim-extra_user_fields", git: "https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git", branch: "temp/twilio-compatibility-0.27"
 gem "decidim-friendly_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.git"
+gem "decidim-half_signup", git: "https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git", branch: "feature/half_signup_and_budgets_booth"
 gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: DECIDIM_BRANCH
 gem "decidim-simple_proposal", git: "https://github.com/opensourcepolitics/decidim-module-simple_proposal.git", branch: DECIDIM_BRANCH
 gem "decidim-slider", git: "https://github.com/OpenSourcePolitics/decidim-module-slider", branch: "rc/0.27"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extra_user_fields.git
-  revision: 25f5a7843a38a5f9360f9bd42eb7e246d997bc7b
-  branch: release/0.27-stable
+  revision: 40edb6a73ee1e21fa939392bcdcd8c0820436460
+  branch: temp/twilio-compatibility-0.27
   specs:
     decidim-extra_user_fields (0.27.2)
       country_select (~> 9.0)
@@ -22,6 +22,15 @@ GIT
   specs:
     decidim-friendly_signup (0.4.6)
       decidim-core (~> 0.27)
+
+GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
+  revision: 5bee2b5422e4131f933ad854ab872e049dcf7b54
+  branch: feature/half_signup_and_budgets_booth
+  specs:
+    decidim-half_signup (0.27.0)
+      countries (~> 5.1, >= 5.1.2)
+      decidim-core (~> 0.27.0)
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git
@@ -288,7 +297,7 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
-    countries (6.0.1)
+    countries (5.7.2)
       unaccent (~> 0.3)
     country_select (9.0.0)
       countries (> 5.0, < 7.0)
@@ -1051,6 +1060,7 @@ DEPENDENCIES
   decidim-dev (~> 0.27.0)
   decidim-extra_user_fields!
   decidim-friendly_signup!
+  decidim-half_signup!
   decidim-homepage_interactive_map!
   decidim-simple_proposal!
   decidim-slider!

--- a/app/services/decidim/sms_gateway_service.rb
+++ b/app/services/decidim/sms_gateway_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "uri"
+require "net/http"
+
+module Decidim
+  class SmsGatewayService
+    attr_reader :mobile_phone_number, :code
+
+    def initialize(mobile_phone_number, code, sms_gateway_context = {})
+      Rails.logger.debug { "#{mobile_phone_number} - #{code}" }
+
+      @mobile_phone_number = mobile_phone_number
+      @code = code
+      @organization_name = sms_gateway_context[:organization]&.name
+      @url = fetch_configuration(:url)
+      @username = fetch_configuration(:username)
+      @password = fetch_configuration(:password)
+      @message = sms_message
+      @type = "sms"
+    end
+
+    def deliver_code
+      url = URI("#{@url}?u=#{@username}&p=#{@password}&t=#{@message}&n=#{@mobile_phone_number}&f=#{@type}")
+      https = Net::HTTP.new(url.host, url.port)
+      https.use_ssl = true
+      request = Net::HTTP::Get.new(url)
+      https.request(request)
+
+      true
+    end
+
+    # Ensure '@code' is not a full i18n keys rather than a verification code.
+    def sms_message
+      return code if code.to_s.length > Decidim::HalfSignup.auth_code_length
+
+      platform = fetch_configuration(:platform, required: false).presence || @organization_name
+      I18n.t("sms_verification_workflow.message", code: code, platform: platform)
+    end
+
+    def fetch_configuration(key, required: true)
+      value = Rails.application.secrets.dig(:decidim, :sms_gateway, key.to_sym)
+      if required && value.blank?
+        Rails.logger.error "Decidim::SmsGatewayService is missing a configuration value for :#{key}, " \
+                           "please check Rails.application.secrets.dig(:decidim, :sms_gateway, :#{key}) " \
+                           "or environment variable SMS_GATEWAY_#{key.to_s.upcase}"
+      end
+      value
+    end
+  end
+end

--- a/app/views/decidim/account/show.html.erb
+++ b/app/views/decidim/account/show.html.erb
@@ -1,0 +1,71 @@
+<%= alert_box("", "account-notification hide", true) %>
+<% add_decidim_page_title(t("profile", scope: "layouts.decidim.user_menu")) %>
+<% content_for(:subtitle) { t("profile", scope: "layouts.decidim.user_menu") } %>
+
+<div class="row">
+  <%= decidim_form_for(@account, url: account_path, method: :put, html: { autocomplete: "off" }) do |f| %>
+    <input autocomplete="off" name="hidden" type="password" style="display:none;">
+    <div class="columns large-4">
+      <%= f.upload :avatar %>
+    </div>
+
+    <div class="columns large-8 end">
+      <% if current_user.unconfirmed_email.present? %>
+        <div id="email-change-pending" class="callout secondary">
+          <p><strong><%= t("decidim.account.email_change.title") %></strong></p>
+          <p><%= t("decidim.account.email_change.body1", unconfirmed_email: current_user.unconfirmed_email) %></p>
+          <p>
+            <%== t(
+                   "decidim.account.email_change.body2",
+                   resend_link: link_to(t("decidim.account.email_change.send_again"), resend_confirmation_instructions_account_path, role: :button, method: :post, remote: true),
+                   cancel_link: link_to(t("decidim.account.email_change.cancel"), cancel_email_change_account_path, role: :button, method: :post, remote: true)) %>
+          </p>
+        </div>
+      <% end %>
+
+      <%= form_required_explanation %>
+
+      <%= f.text_field :name, autocomplete: "name" %>
+      <%= f.text_field :nickname, autocomplete: "nickname" %>
+      <%= f.email_field :email, disabled: current_user.unconfirmed_email.present?, autocomplete: "email" %>
+      <%= render partial: "change_phone_number", locals: { f: f, account: @account }  if half_signup_handlers.include?("sms") %>
+      <%= f.url_field :personal_url, autocomplete: "url" %>
+      <%= f.text_area :about, rows: 5 %>
+
+      <% if @account.organization.available_locales.size > 1 %>
+        <%= f.collection_select(
+              :locale,
+              @account.organization.available_locales,
+              :to_s,
+              ->(locale) {locale_name(locale) }
+            ) %>
+      <% else %>
+        <%= f.collection_select(
+              :locale,
+              @account.organization.available_locales,
+              :to_s,
+              ->(locale) {locale_name(locale) },
+              {},
+              { disabled: true }
+            ) %>
+      <% end %>
+
+      <p class="help-text"><%= t(".available_locales_helper") %></p>
+
+      <% if @account.errors[:password].any? || @account.errors[:password_confirmation].any? %>
+        <%= render partial: "password_fields", locals: { form: f } %>
+      <% else %>
+        <% if current_organization.sign_in_enabled? %>
+          <p>
+            <button type="button" data-toggle="passwordChange" class="link change-password"><%= t ".change_password" %></button>
+          </p>
+          <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
+            <%= render partial: "password_fields", locals: { form: f } %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t(".update_account") %>
+    </div>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,7 @@ module DevelopmentApp
       require "extends/commands/decidim/meetings/update_meeting_extends"
       require "extends/commands/decidim/meetings/create_meeting_extends"
       require "extends/models/decidim/decidim_awesome/proposal_extra_field_extends"
+      require "extends/models/decidim/user_extends"
 
       Decidim::GraphiQL::Rails.config.tap do |config|
         config.initial_query = "{\n  deployment {\n    version\n    branch\n    remote\n    upToDate\n    currentCommit\n    latestCommit\n    locallyModified\n  }\n}".html_safe

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -98,6 +98,9 @@ ignore_missing:
  - decidim.proposals.proposals.placeholder.address
  - decidim.proposals.collaborative_drafts.edit.select_a_category
  - decidim.proposals.collaborative_drafts.edit.attachment_legend
+ - decidim.account.email_change.*
+ - decidim.account.show.*
+ - layouts.decidim.user_menu.profile
  - activemodel.attributes.proposal.address
  - devise.shared.links.sign_in_with_provider
  - decidim.devise.shared.omniauth_buttons.or

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -75,7 +75,7 @@ Decidim.configure do |config|
   #   end
   # end
   #
-  # config.sms_gateway_service = 'Decidim::Verifications::Sms::ExampleGateway'
+  config.sms_gateway_service = Rails.application.secrets.dig(:decidim, :sms_gateway, :service)
 
   # Etherpad configuration
   #

--- a/config/initializers/half_signup.rb
+++ b/config/initializers/half_signup.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+return unless defined?(Decidim::HalfSignup)
+
+Decidim::HalfSignup.configure do |config|
+  config.show_tos_page_after_signup = Rails.application.secrets.dig(:decidim, :half_signup, :show_tos_page_after_signup)
+  config.auth_code_length = 4
+  config.default_countries = ENV.fetch("AVAILABLE_LOCALES", "fr").split(",").map(&:to_sym)
+
+  config.skip_csrf = ENV.fetch("HALF_SIGNUP_SKIP_CSRF", "false") == "true"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,3 +333,5 @@ en:
       time: 'You will be able to navigate on our website in :'
       time_unit: seconds
       title: Thank you for your participation on %{organization_name}
+  sms_verification_workflow:
+    message: 'Hello, here is the code to authenticate yourself on the %{platform} platform: %{code}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -343,3 +343,5 @@ fr:
       time: 'Vous pourrez naviguer de nouveau sur notre plateforme dans :'
       time_unit: seconds
       title: Thank you for your participation on %{organization_name}
+  sms_verification_workflow:
+    message: 'Bonjour, %{code} est le code pour vous authentifier sur la plateforme %{platform}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -344,4 +344,4 @@ fr:
       time_unit: seconds
       title: Thank you for your participation on %{organization_name}
   sms_verification_workflow:
-    message: 'Bonjour, %{code} est le code pour vous authentifier sur la plateforme %{platform}'
+    message: Bonjour, %{code} est le code pour vous authentifier sur la plateforme %{platform}

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,8 @@ default: &default
     decidim_awesome:
       weighted_proposal_voting_enabled: <%= ENV.fetch("DECIDIM_AWESOME_WEIGHTED_PROPOSAL_VOTING_ENABLED", "disabled") %>
     currency: <%= ENV["CURRENCY"] || "€" %>
+    half_signup:
+      show_tos_page_after_signup: <%= ENV.fetch("DECIDIM_HALF_SIGNUP_SHOW_TOS_PAGE_AFTER_SIGNUP", "true") == "true" %>
     rack_attack:
       enabled: <%= ENV["ENABLE_RACK_ATTACK"] %>
       fail2ban:
@@ -23,6 +25,15 @@ default: &default
       throttle:
         max_requests: <%= ENV["THROTTLING_MAX_REQUESTS"]&.to_i || 100 %>
         period: <%= ENV["THROTTLING_PERIOD"]&.to_i || 60 %>
+    sms_gateway:
+      service: <%= ENV.fetch("SMS_GATEWAY_SERVICE", "Decidim::Verifications::Sms::ExampleGateway") %>
+      url: <%= ENV["SMS_GATEWAY_URL"] %>
+      bulk_url: <%= ENV["SMS_GATEWAY_BULK_URL"] %>
+      username: <%= ENV["SMS_GATEWAY_USERNAME"] %>
+      password: <%= ENV["SMS_GATEWAY_PASSWORD"] %>
+      platform: <%= ENV["SMS_GATEWAY_PLATFORM"] %>
+      mb_api_key: <%= ENV["SMS_GATEWAY_MB_API_KEY"] %>
+      mb_account_id: <%= ENV["SMS_GATEWAY_MB_ACCOUNT_ID"] %>
   scaleway:
     id: <%= ENV["SCALEWAY_ID"] %>
     token: <%= ENV["SCALEWAY_TOKEN"] %>

--- a/db/migrate/20241219100637_create_auth_settings.decidim_half_signup.rb
+++ b/db/migrate/20241219100637_create_auth_settings.decidim_half_signup.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This migration comes from decidim_half_signup (originally 20230214091207)
+
+class CreateAuthSettings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_half_signup_auth_settings do |t|
+      t.boolean :enable_partial_sms_signup, default: false
+      t.boolean :enable_partial_email_signup, default: false
+      t.string :slug
+      t.references :decidim_organization, foreign_key: true, index: { name: :index_half_signup_auth_settings_on_organization_id }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241219100638_add_phone_number_to_decidim_user.decidim_half_signup.rb
+++ b/db/migrate/20241219100638_add_phone_number_to_decidim_user.decidim_half_signup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_half_signup (originally 20230215093510)
+
+class AddPhoneNumberToDecidimUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_users, :phone_number, :string
+    add_column :decidim_users, :phone_country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_08_065657) do
+ActiveRecord::Schema.define(version: 2024_12_19_100638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -742,6 +742,16 @@ ActiveRecord::Schema.define(version: 2024_10_08_065657) do
     t.string "badge_name", null: false
     t.integer "value", default: 0, null: false
     t.index ["user_id"], name: "index_decidim_gamification_badge_scores_on_user_id"
+  end
+
+  create_table "decidim_half_signup_auth_settings", force: :cascade do |t|
+    t.boolean "enable_partial_sms_signup", default: false
+    t.boolean "enable_partial_email_signup", default: false
+    t.string "slug"
+    t.bigint "decidim_organization_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["decidim_organization_id"], name: "index_half_signup_auth_settings_on_organization_id"
   end
 
   create_table "decidim_hashtags", force: :cascade do |t|
@@ -1761,6 +1771,8 @@ ActiveRecord::Schema.define(version: 2024_10_08_065657) do
     t.datetime "digest_sent_at"
     t.datetime "password_updated_at"
     t.string "previous_passwords", default: [], array: true
+    t.string "phone_number"
+    t.string "phone_country"
     t.index ["confirmation_token"], name: "index_decidim_users_on_confirmation_token", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_users_on_decidim_organization_id"
     t.index ["email", "decidim_organization_id"], name: "index_decidim_users_on_email_and_decidim_organization_id", unique: true, where: "((deleted_at IS NULL) AND (managed = false) AND ((type)::text = 'Decidim::User'::text))"
@@ -1889,6 +1901,7 @@ ActiveRecord::Schema.define(version: 2024_10_08_065657) do
   add_foreign_key "decidim_debates_debates", "decidim_scopes"
   add_foreign_key "decidim_editor_images", "decidim_organizations"
   add_foreign_key "decidim_editor_images", "decidim_users", column: "decidim_author_id"
+  add_foreign_key "decidim_half_signup_auth_settings", "decidim_organizations"
   add_foreign_key "decidim_identities", "decidim_organizations"
   add_foreign_key "decidim_newsletters", "decidim_users", column: "author_id"
   add_foreign_key "decidim_participatory_process_steps", "decidim_participatory_processes"

--- a/lib/extends/models/decidim/user_extends.rb
+++ b/lib/extends/models/decidim/user_extends.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module UserExtends
+  extend ActiveSupport::Concern
+
+  included do
+    def needs_password_update?
+      return false if organization.users_registration_mode == "disabled"
+      return false unless admin?
+      return false unless Decidim.config.admin_password_strong
+      return true if password_updated_at.blank?
+
+      password_updated_at < Decidim.config.admin_password_expiration_days.days.ago
+    end
+  end
+end
+
+Decidim::User.include(UserExtends)


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR adds the "Half Signup" feature through middleware, allowing users to create a "partial" account using their email or phone number. This ensures easier voting while verifying user identity for each voting action. Additionally, untested overrides or not matching the last versions of it, such as User model extensions and the `account/show.erb` view, have been added to align with Decidim's `release/0.27-stable` branch, incorporating "Half Signup" adjustments like phone number editing.

#### :pushpin: Related Issues

- [Ajout du module Half sign up ](https://www.notion.so/opensourcepolitics/Decidim-app-2-2-Ajout-module-half-sign-up-acdc92c247fa42db8cd4ca2afdad7e50?pvs=4)

#### 🔧 How to test 

### 💻  App Setup 
- You'll need to add multiple environment variables if you want to test that the gateway works correctly
```
SMS_GATEWAY_USERNAME=<provider_username>
SMS_GATEWAY_PASSWORD=<provider_password>
SMS_GATEWAY_SERVICE="Decidim::SmsGatewayService"
SMS_GATEWAY_URL=<provider_url> 
```

### 💾  Backoffice setup
- Access to BackOffice
- Enable HalfSignup any method you want (may be great to test both of them individually then together)
- Go into a participatory process
- Click on categories
- Create some custom categories using the gem budget_category_voting (precompile deface if it's not displaying correctly)
- Access a budgets component settings
- Enable the option to ensure the user choose at least one project
- Access the budgets edition (not the setting but the place where every budgets are listed onto your component)
- Click on a budget
- Setup your budget using budget_category_voting  and select at least one project of a created category to make sure about the compatibility of budgets booth and budget_category_voting
- Access the projects onto your budget and modify some categories or create new ones to make sure your conditions can be fullfilled

### 🖼️ Front Office Test


##### ✂️ Half Signup account
- Click to vote
- Make sure you are redirected
- Put a random phone number (SMS method case)
- Put a random email (EMAIL method case)
- Follow the given instructions
- Access the budgets booth page
- Select your projects
- Leave the page by cancelling the vote
- You must be disconnected
- You should not be able to vote unless you selected a project of your required category
- Confirm your vote
- Make sure you are logged out afterwards

##### 🇪🇸 Decidim Account
- Log in as a decidim user
- Click to vote
- Make sure even if the activated that you're not redirected to the email confirmation (totally counterproductive regarding the UX)
- Put a phone number (If sms method is enabled)
- Verify that you are directly redirected to the budget (if sms method is disabled)
- Access the budgets booth page
- Select your projects
- You should not be able to vote unless you selected a project of your required category
- Leave the page by cancelling the vote
- You mustn't be disconnected
- Try to reaccess the same budget or another one
- Make sure you are redirected to the quick_auth page before accessing again to the vote (if sms method is enabled)


#### Tasks
- [x] Add module
- [x] Change branch of EUF to ensure compatibility
- [x] Add migrations
- [x] Add the SMS Gateway to ensure the SMS sending
- [x] Update env variables
- [x] Update the secrets to match new env vars and addition of the Gateway   
- [x] Fix multiple specs that were crashing due to Half Signup modifications