### PR TITLE
Fix notifications settings page

### DIFF
--- a/lib/extends/models/decidim/user_extends.rb
+++ b/lib/extends/models/decidim/user_extends.rb
@@ -13,6 +13,14 @@ module UserExtends
 
       password_updated_at < Decidim.config.admin_password_expiration_days.days.ago
     end
+
+    def moderator?
+      Decidim.participatory_space_manifests.map do |manifest|
+        participatory_space_type = manifest.model_class_name.constantize
+        return true if participatory_space_type.moderators(organization).exists?(id)
+      end
+      false
+    end
   end
 end
 


### PR DESCRIPTION
#### :tophat: Description
The notifications settings page does not display correctly

#### :pushpin: Related Issues
- [Odoo](https://opensourcepolitics.odoo.com/odoo/action-465/140/tasks/4095)

#### Testing
1. Log in as admin or user
2. Go to your account and click on 'notifications settings'
3. See that you have the notifications settings page is displayed correctly 🎉 

### :camera: Screenshots
<img width="1243" alt="Capture d’écran 2025-02-13 à 14 59 23" src="https://github.com/user-attachments/assets/ef7bd566-3c90-4842-ac59-0cea6d02cacb" />