### PR TITLE
backport: Remove config entry to enforce OSM default over HERE

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -21,9 +21,21 @@ Decidim.configure do |config|
   config.maps = {
     provider: :here,
     api_key: Rails.application.secrets.maps[:api_key],
-    static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" },
+
+    # Keep HERE as the default provider for autocomplete
     autocomplete: {
       address_format: [%w(houseNumber street), "city", "country"]
+    },
+
+    # Change to OSM for dynamic maps to avoid usage limits from HERE
+    dynamic: {
+      provider: :osm,
+      tile_layer: {
+        url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        attribution: %(
+        &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors
+      )
+      }
     }
   }
 


### PR DESCRIPTION
#### :tophat: Description

It changes the way we handle dynamic map loading in the Decidim-App, as we were exceeding the daily quota by loading tiles through the "Here" service. We decided to use the OpenStreetMap service instead, which imposes fewer restrictions on API calls.

It also fixes the issue where "static" maps were not displaying due to a configuration setting that was enforcing the use of the "HERE" service. This was preventing map generation when the daily quota was exceeded.

#### :pushpin: Related Issues

- [🐛 BUG Map (proposals geo) not showing](https://opensourcepolitics.odoo.com/odoo/all-tasks/4133)
- [Backport dcd-app fix: Change the dynamic maps loading using OpenStreetMap #685](https://github.com/OpenSourcePolitics/decidim-app/pull/685)

### Testing

#### Please note that if you want to make a complete test you'll need to test using the API key of here (especially for the geocoding but you can test without it)

#### First Test 
* Access Homepage
* Make sure Decidim Awesome Map and Homepage Interactive Map are loading correctly using OSM service

#### Second Test (API key required)
* Access Backoffice
* Go to organization settings
* Access a PP's Proposals component's settings
* Add the geocoding to the proposals
* Access Front Office
* Create a proposal
* Make sure you can use geocoding
* Make sure on the preview that the static map is displayed correctly
* As it is created make sure it's correctly displayed as a marker on the map
* You can create new ones and make sure it'll be displayed correctly

#### Tasks
- [x] Change Config to use OSM as the dynamic map provider and keep here for the static maps and the geocoding
