### PR TITLE
bump: Half signup to last release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-half_sign_up.git
-  revision: 3595311ab355312986f11e38f8c38638832342a2
+  revision: b449e37dca1a51fc03824b6f37811b18806febe5
   branch: middleware-1.0.0
   specs:
     decidim-half_signup (0.27.0)


### PR DESCRIPTION
#### :tophat: Description
Bump half signup to fix last issues regarding the error management

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Lyon - Bump module half sign up #740](https://github.com/OpenSourcePolitics/decidim-app/issues/740)

#### Testing

1. **Log in** as an admin user.  
2. **Open the Backoffice**.  
3. Navigate to **Organization Settings** → **Authentication Settings**.  
4. **Enable SMS Authentication**.  
5. Go to a **Participatory Process** and access its **Budgets component**.  
6. Modify the settings to **allow voting on all budgets** (to simplify testing).  
7. Open the **Front-Office**.  
8. **Attempt to vote** using **Half Signup**.  
9. **Confirm** that the voting process works correctly.  
10. **Log in again** and **wait 5 minutes** before entering the verification code.  
11. Verify that a **flash alert** appears indicating the **code has expired**.


#### Tasks
- [x] Bump module
