### PR TITLE
feat: bump module ptp

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -164,6 +164,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
       - run: |
+          sudo apt update
           sudo apt install libu2f-udev imagemagick
           wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${{env.CHROME_VERSION}}-1_amd64.deb
           sudo dpkg -i /tmp/chrome.deb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: 9f02c08e6715deb3c32569ecd4ec3a4385fd2b00
+  revision: e2ec0dd39b5e8b96b88986c494087a9e87e94d2e
   specs:
     decidim-budgets_booth (0.27.0)
       decidim-budgets (~> 0.27.0)


### PR DESCRIPTION
#### :tophat: Description
This PR bumps the decidim-module_ptp to its latest commit.

#### :pushpin: Related Issues
- [Github card](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=109081684&issue=OpenSourcePolitics%7Cdecidim-lyon%7C145)

#### Testing

1. To test the PR, go to decidim-lyon develop and update in the gemfile the line for budgets_booth gem like this gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/projects_display_on_map"
2. Bundle install
3. As an admin, go to a process, go to the Budgets component and enable geocoding in the configuration page, and set the project per page to 3
4. Choose a budget with 2 projects.
5. Create 4 new projects with addresses.
6. In FO, go to the projects index view: see that the map is displayed and that the projects displayed on the map match the projects listed on the page.
7. Go to page 2, and check again that the projects displayed on the map match the projects listed on the page.


### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
