### PR TITLE
bump: module ptp to fix display of projects in map when using filters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GIT
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-ptp.git
-  revision: 9f02c08e6715deb3c32569ecd4ec3a4385fd2b00
+  revision: 9ea26682739486ce4ca30a814747e88e57e70524
   specs:
     decidim-budgets_booth (0.27.0)
       decidim-budgets (~> 0.27.0)


### PR DESCRIPTION
🎩 Description
This PR bumps the decidim-module_ptp to its latest commit.

📌 Related Issues
https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=109081684&issue=OpenSourcePolitics%7Cdecidim-lyon%7C145

#### Testing
To test the PR, go to decidim-lyon develop and update in the gemfile the line for budgets_booth gem like this gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/projects_display_on_map"
Bundle install
As an admin, go to a process, go to the Budgets component and enable geocoding in the configuration page, and set the project per page to 3
Choose a budget with 2 projects.
Create 4 new projects with addresses.
In FO, go to the projects index view: see that the map is displayed and that the projects displayed on the map match the projects listed on the page.
Filter the projects using the filters on the left and see that the projects displayed on the map match the projects listed on the page

