### PR TITLE
Fix projects list with filters

### DIFF
--- a/app/controllers/decidim/budgets/projects_controller.rb
+++ b/app/controllers/decidim/budgets/projects_controller.rb
@@ -29,7 +29,14 @@ module Decidim
         return @projects if @projects
 
         @projects = reorder(search.result)
-        @projects = @projects.page(params[:page]).per(current_component.settings.projects_per_page)
+        ids = @projects.pluck(:id)
+
+        # keep the order so that when we use filters and pagination, projects are always
+        # displayed in the same order on the pages
+        @projects = Decidim::Budgets::Project.where(id: ids)
+                                             .order(Arel.sql("position(id::text in '#{ids.join(',')}')"))
+                                             .page(params[:page])
+                                             .per(current_component.settings.projects_per_page)
       end
 
       def all_geocoded_projects

--- a/app/controllers/decidim/budgets/projects_controller.rb
+++ b/app/controllers/decidim/budgets/projects_controller.rb
@@ -34,7 +34,7 @@ module Decidim
         # keep the order so that when we use filters and pagination, projects are always
         # displayed in the same order on the pages
         @projects = Decidim::Budgets::Project.where(id: ids)
-                                             .order(Arel.sql("position(id::text in '#{ids.join(',')}')"))
+                                             .order(Arel.sql("position(id::text in '#{ids.join(",")}')"))
                                              .page(params[:page])
                                              .per(current_component.settings.projects_per_page)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ Capybara.register_driver :headless_chrome do |app|
                     "--window-size=1920,1080"
                   end
   options.args << "--ignore-certificate-errors" if ENV["TEST_SSL"]
+  options.add_preference("intl.accept_languages", "en-GB")
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,

--- a/spec/system/explore_projects_spec.rb
+++ b/spec/system/explore_projects_spec.rb
@@ -85,7 +85,7 @@ describe "Explore projects", :slow, type: :system do
           first_cate = categories.first
           sec_cate = categories.last
           projects.each_with_index do |project, index|
-            index.even? ? project.category = first_cate : project.category = sec_cate
+            project.category = index.even? ? first_cate : sec_cate
             project.save
           end
 
@@ -100,7 +100,7 @@ describe "Explore projects", :slow, type: :system do
             expect(page).to have_css(".budget-list__item", count: 3)
           end
 
-          budget_list = all('div.budget-list__item')
+          budget_list = all("div.budget-list__item")
           first_proj = budget_list[0][:id]
           sec_proj = budget_list[1][:id]
           third_proj = budget_list[2][:id]
@@ -117,7 +117,7 @@ describe "Explore projects", :slow, type: :system do
           end
 
           # check that the projects are displayed in the same order on page one
-          new_budget_list = all('div.budget-list__item')
+          new_budget_list = all("div.budget-list__item")
           expect(new_budget_list[0][:id]).to eq(first_proj)
           expect(new_budget_list[1][:id]).to eq(sec_proj)
           expect(new_budget_list[2][:id]).to eq(third_proj)


### PR DESCRIPTION
#### :tophat: Description
This PR keeps the order of projects in projects index view when filtering and then using pagination.

#### :pushpin: Related Issues
- [Github card](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=109437478&issue=OpenSourcePolitics%7Cdecidim-lyon%7C147)

#### Testing

1. In BO, go to a budget and add several projects with 2 different categories
2. On the budget component, change the number of projects per page to 4
3. In FO, go to the projects index view
4. Filter by category and keep in mind the projects displayed on page one
5. Go to page 2 and then go back to page one and see that the projects displayed on page one are the same as before.
6.  Go to the projects index view in another browser, repeat the step 4 and check that the projects displayed are different from the ones displayed in first browser. 
7. Repeat step 5 and see that it works as expected

#### Tasks
- [X] Add specs

